### PR TITLE
V4 - BinaryKits.Zpl.Protocol

### DIFF
--- a/src/BinaryKits.Zpl.Protocol.UnitTest/BinaryKits.Zpl.Protocol.UnitTest.csproj
+++ b/src/BinaryKits.Zpl.Protocol.UnitTest/BinaryKits.Zpl.Protocol.UnitTest.csproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.4" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.4" />
+    <PackageReference Include="coverlet.collector" Version="3.0.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\BinaryKits.Zpl.Protocol\BinaryKits.Zpl.Protocol.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/BarCodeFieldDefaultCommandTest.cs
+++ b/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/BarCodeFieldDefaultCommandTest.cs
@@ -23,14 +23,14 @@ namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
         }
 
         [TestMethod]
-        [ExpectedException(typeof(ArgumentException), "Must be between 1 and 10")]
+        [ExpectedException(typeof(ArgumentException))]
         public void Constructor_InvalidModuleWidth1_Exception()
         {
             new BarCodeFieldDefaultCommand(0, 3, 10);
         }
 
         [TestMethod]
-        [ExpectedException(typeof(ArgumentException), "Must be between 1 and 10")]
+        [ExpectedException(typeof(ArgumentException))]
         public void Constructor_InvalidModuleWidth2_Exception()
         {
             new BarCodeFieldDefaultCommand(11, 3, 10);

--- a/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/BarCodeFieldDefaultCommandTest.cs
+++ b/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/BarCodeFieldDefaultCommandTest.cs
@@ -1,0 +1,85 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+
+namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
+{
+    [TestClass]
+    public class BarCodeFieldDefaultCommandTest
+    {
+        [TestMethod]
+        public void ToZpl_Default1_Successful()
+        {
+            var command = new BarCodeFieldDefaultCommand(2, 3.0, 10);
+            var zplCommand = command.ToZpl();
+            Assert.AreEqual("^BY2,3.0,10", zplCommand);
+        }
+
+        [TestMethod]
+        public void ToZpl_Default2_Successful()
+        {
+            var command = new BarCodeFieldDefaultCommand(2, 2.91, 10);
+            var zplCommand = command.ToZpl();
+            Assert.AreEqual("^BY2,2.9,10", zplCommand);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException), "Must be between 1 and 10")]
+        public void Constructor_InvalidModuleWidth1_Exception()
+        {
+            new BarCodeFieldDefaultCommand(0, 3, 10);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException), "Must be between 1 and 10")]
+        public void Constructor_InvalidModuleWidth2_Exception()
+        {
+            new BarCodeFieldDefaultCommand(11, 3, 10);
+        }
+
+        [TestMethod]
+        public void IsCommandParsable_ValidCommand_True()
+        {
+            var command = new BarCodeFieldDefaultCommand();
+            var isParsable = command.IsCommandParsable("^BY2,2.9,10");
+            Assert.IsTrue(isParsable);
+        }
+
+        [TestMethod]
+        public void IsCommandParsable_InvalidCommand_False()
+        {
+            var command = new BarCodeFieldDefaultCommand();
+            var isParsable = command.IsCommandParsable("^FT10,10");
+            Assert.IsFalse(isParsable);
+        }
+
+        [TestMethod]
+        public void ParseCommand_ValidCommand1_Successful()
+        {
+            var command = new BarCodeFieldDefaultCommand();
+            command.ParseCommand("^BY2,2.9,10");
+            Assert.AreEqual(2, command.ModuleWidth);
+            Assert.AreEqual(2.9, command.WideBarToNarrowBarWidthRatio);
+            Assert.AreEqual(10, command.BarCodeHeight);
+        }
+
+        [TestMethod]
+        public void ParseCommand_ValidCommand2_Successful()
+        {
+            var command = new BarCodeFieldDefaultCommand();
+            command.ParseCommand("^BY5,2.0,50");
+            Assert.AreEqual(5, command.ModuleWidth);
+            Assert.AreEqual(2.0, command.WideBarToNarrowBarWidthRatio);
+            Assert.AreEqual(50, command.BarCodeHeight);
+        }
+
+        [TestMethod]
+        public void ParseCommand_ValidCommandXisEmpty_Successful()
+        {
+            var command = new BarCodeFieldDefaultCommand();
+            command.ParseCommand("^BY2,2.9,100");
+            Assert.AreEqual(2, command.ModuleWidth);
+            Assert.AreEqual(2.9, command.WideBarToNarrowBarWidthRatio);
+            Assert.AreEqual(100, command.BarCodeHeight);
+        }
+    }
+}

--- a/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/ChangeAlphanumericDefaultFontCommandTest.cs
+++ b/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/ChangeAlphanumericDefaultFontCommandTest.cs
@@ -1,0 +1,103 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+
+namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
+{
+    [TestClass]
+    public class ChangeAlphanumericDefaultFontCommandTest
+    {
+        [TestMethod]
+        public void ToZpl_Default1_Successful()
+        {
+            var command = new ChangeAlphanumericDefaultFontCommand('A');
+            var zplCommand = command.ToZpl();
+            Assert.AreEqual("^CFA,,", zplCommand);
+        }
+
+        [TestMethod]
+        public void ToZpl_Default2_Successful()
+        {
+            var command = new ChangeAlphanumericDefaultFontCommand('A', 10);
+            var zplCommand = command.ToZpl();
+            Assert.AreEqual("^CFA,10,", zplCommand);
+        }
+
+        [TestMethod]
+        public void ToZpl_Default3_Successful()
+        {
+            var command = new ChangeAlphanumericDefaultFontCommand('D', 400, 5000);
+            var zplCommand = command.ToZpl();
+            Assert.AreEqual("^CFD,400,5000", zplCommand);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void Constructor_InvalidIndividualCharacterHeight_Exception()
+        {
+            new ChangeAlphanumericDefaultFontCommand('A', 600000);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void Constructor_InvalidIndividualCharacterWidth_Exception()
+        {
+            new ChangeAlphanumericDefaultFontCommand('A', 1, 600000);
+        }
+
+        [TestMethod]
+        public void IsCommandParsable_ValidCommand_True()
+        {
+            var command = new ChangeAlphanumericDefaultFontCommand();
+            var isParsable = command.IsCommandParsable("^CFA,9,5");
+            Assert.IsTrue(isParsable);
+        }
+
+        [TestMethod]
+        public void IsCommandParsable_InvalidCommand_False()
+        {
+            var command = new ChangeAlphanumericDefaultFontCommand();
+            var isParsable = command.IsCommandParsable("^FT10,10");
+            Assert.IsFalse(isParsable);
+        }
+
+        [TestMethod]
+        public void ParseCommand_ValidCommand1_Successful()
+        {
+            var command = new ChangeAlphanumericDefaultFontCommand();
+            command.ParseCommand("^CFA,,");
+            Assert.AreEqual('A', command.SpecifiedDefaultFont);
+            Assert.IsNull(command.IndividualCharacterHeight);
+            Assert.IsNull(command.IndividualCharacterWidth);
+        }
+
+        [TestMethod]
+        public void ParseCommand_ValidCommand2_Successful()
+        {
+            var command = new ChangeAlphanumericDefaultFontCommand();
+            command.ParseCommand("^CFB,10,20");
+            Assert.AreEqual('B', command.SpecifiedDefaultFont);
+            Assert.AreEqual(10, command.IndividualCharacterHeight);
+            Assert.AreEqual(20, command.IndividualCharacterWidth);
+        }
+
+        [TestMethod]
+        public void ParseCommand_ValidCommand3_Successful()
+        {
+            var command = new ChangeAlphanumericDefaultFontCommand();
+            command.ParseCommand("^CFB,,20");
+            Assert.AreEqual('B', command.SpecifiedDefaultFont);
+            Assert.IsNull(command.IndividualCharacterHeight);
+            Assert.AreEqual(20, command.IndividualCharacterWidth);
+        }
+
+        [TestMethod]
+        public void ParseCommand_ValidCommand4_Successful()
+        {
+            var command = new ChangeAlphanumericDefaultFontCommand();
+            command.ParseCommand("^CFB,500,");
+            Assert.AreEqual('B', command.SpecifiedDefaultFont);
+            Assert.AreEqual(500, command.IndividualCharacterHeight);
+            Assert.IsNull(command.IndividualCharacterWidth);
+        }
+    }
+}

--- a/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/Code128BarCodeCommandTest.cs
+++ b/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/Code128BarCodeCommandTest.cs
@@ -110,7 +110,7 @@ namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
             var command = new Code128BarCodeCommand();
             command.ParseCommand("^BCR,20,N,N,N");
             Assert.AreEqual(Orientation.Rotated90, command.Orientation);
-            Assert.AreEqual(command.BarCodeHeight, 20);
+            Assert.AreEqual(20, command.BarCodeHeight);
             Assert.IsFalse(command.PrintInterpretationLine);
             Assert.IsFalse(command.PrintInterpretationLineAboveCode);
             Assert.IsFalse(command.UccCheckDigit);
@@ -122,7 +122,7 @@ namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
             var command = new Code128BarCodeCommand();
             command.ParseCommand("^BCB,55");
             Assert.AreEqual(Orientation.Rotated270, command.Orientation);
-            Assert.AreEqual(command.BarCodeHeight, 55);
+            Assert.AreEqual(55, command.BarCodeHeight);
             Assert.IsTrue(command.PrintInterpretationLine);
             Assert.IsFalse(command.PrintInterpretationLineAboveCode);
             Assert.IsFalse(command.UccCheckDigit);

--- a/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/Code128BarCodeCommandTest.cs
+++ b/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/Code128BarCodeCommandTest.cs
@@ -1,0 +1,143 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+
+namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
+{
+    [TestClass]
+    public class Code128BarCodeCommandTest
+    {
+        [TestMethod]
+        public void ToZpl_Default1_Successful()
+        {
+            var command = new Code128BarCodeCommand();
+            var zplCommand = command.ToZpl();
+            Assert.AreEqual("^BCN,,Y,N,N", zplCommand);
+        }
+
+        [TestMethod]
+        public void ToZpl_Default2_Successful()
+        {
+            var command = new Code128BarCodeCommand(Orientation.Rotated180);
+            var zplCommand = command.ToZpl();
+            Assert.AreEqual("^BCI,,Y,N,N", zplCommand);
+        }
+
+        [TestMethod]
+        public void ToZpl_Default3_Successful()
+        {
+            var command = new Code128BarCodeCommand(barCodeHeight: 10);
+            var zplCommand = command.ToZpl();
+            Assert.AreEqual("^BCN,10,Y,N,N", zplCommand);
+        }
+
+        [TestMethod]
+        public void ToZpl_Default4_Successful()
+        {
+            var command = new Code128BarCodeCommand(printInterpretationLine: false, printInterpretationLineAboveCode: false, uccCheckDigit: true);
+            var zplCommand = command.ToZpl();
+            Assert.AreEqual("^BCN,,N,N,Y", zplCommand);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException), "Must be between 1 and 32000")]
+        public void Constructor_InvalidBarCodeHeight1_Exception()
+        {
+            new Code128BarCodeCommand(barCodeHeight: 0);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException), "Must be between 1 and 32000")]
+        public void Constructor_InvalidBarCodeHeight2_Exception()
+        {
+            new Code128BarCodeCommand(barCodeHeight: 33000);
+        }
+
+        [TestMethod]
+        public void IsCommandParsable_ValidCommand_True()
+        {
+            var command = new Code128BarCodeCommand();
+            var isParsable = command.IsCommandParsable("^BCN,,N,N,Y");
+            Assert.IsTrue(isParsable);
+        }
+
+        [TestMethod]
+        public void IsCommandParsable_InvalidCommand_False()
+        {
+            var command = new Code128BarCodeCommand();
+            var isParsable = command.IsCommandParsable("^FT10,10");
+            Assert.IsFalse(isParsable);
+        }
+
+        [TestMethod]
+        public void ParseCommand_ValidCommand1_Successful()
+        {
+            var command = new Code128BarCodeCommand();
+            command.ParseCommand("^BCN,,N,N,Y");
+            Assert.AreEqual(Orientation.Normal, command.Orientation);
+            Assert.IsNull(command.BarCodeHeight);
+            Assert.IsFalse(command.PrintInterpretationLine);
+            Assert.IsFalse(command.PrintInterpretationLineAboveCode);
+            Assert.IsTrue(command.UccCheckDigit);
+        }
+
+        [TestMethod]
+        public void ParseCommand_ValidCommand2_Successful()
+        {
+            var command = new Code128BarCodeCommand();
+            command.ParseCommand("^BCN,,Y,Y,Y");
+            Assert.AreEqual(Orientation.Normal, command.Orientation);
+            Assert.IsNull(command.BarCodeHeight);
+            Assert.IsTrue(command.PrintInterpretationLine);
+            Assert.IsTrue(command.PrintInterpretationLineAboveCode);
+            Assert.IsTrue(command.UccCheckDigit);
+        }
+
+        [TestMethod]
+        public void ParseCommand_ValidCommand3_Successful()
+        {
+            var command = new Code128BarCodeCommand();
+            command.ParseCommand("^BCN,,N,N,N");
+            Assert.AreEqual(Orientation.Normal, command.Orientation);
+            Assert.IsNull(command.BarCodeHeight);
+            Assert.IsFalse(command.PrintInterpretationLine);
+            Assert.IsFalse(command.PrintInterpretationLineAboveCode);
+            Assert.IsFalse(command.UccCheckDigit);
+        }
+
+        [TestMethod]
+        public void ParseCommand_ValidCommand4_Successful()
+        {
+            var command = new Code128BarCodeCommand();
+            command.ParseCommand("^BCR,20,N,N,N");
+            Assert.AreEqual(Orientation.Rotated90, command.Orientation);
+            Assert.AreEqual(command.BarCodeHeight, 20);
+            Assert.IsFalse(command.PrintInterpretationLine);
+            Assert.IsFalse(command.PrintInterpretationLineAboveCode);
+            Assert.IsFalse(command.UccCheckDigit);
+        }
+
+        [TestMethod]
+        public void ParseCommand_ValidCommand5_Successful()
+        {
+            var command = new Code128BarCodeCommand();
+            command.ParseCommand("^BCB,55");
+            Assert.AreEqual(Orientation.Rotated270, command.Orientation);
+            Assert.AreEqual(command.BarCodeHeight, 55);
+            Assert.IsTrue(command.PrintInterpretationLine);
+            Assert.IsFalse(command.PrintInterpretationLineAboveCode);
+            Assert.IsFalse(command.UccCheckDigit);
+        }
+
+        [TestMethod]
+        public void ParseCommand_ValidCommand6_Successful()
+        {
+            var command = new Code128BarCodeCommand();
+            command.ParseCommand("^BC");
+            Assert.AreEqual(Orientation.Normal, command.Orientation);
+            Assert.IsNull(command.BarCodeHeight);
+            Assert.IsTrue(command.PrintInterpretationLine);
+            Assert.IsFalse(command.PrintInterpretationLineAboveCode);
+            Assert.IsFalse(command.UccCheckDigit);
+        }
+    }
+}

--- a/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/Code128BarCodeCommandTest.cs
+++ b/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/Code128BarCodeCommandTest.cs
@@ -39,14 +39,14 @@ namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
         }
 
         [TestMethod]
-        [ExpectedException(typeof(ArgumentException), "Must be between 1 and 32000")]
+        [ExpectedException(typeof(ArgumentException))]
         public void Constructor_InvalidBarCodeHeight1_Exception()
         {
             new Code128BarCodeCommand(barCodeHeight: 0);
         }
 
         [TestMethod]
-        [ExpectedException(typeof(ArgumentException), "Must be between 1 and 32000")]
+        [ExpectedException(typeof(ArgumentException))]
         public void Constructor_InvalidBarCodeHeight2_Exception()
         {
             new Code128BarCodeCommand(barCodeHeight: 33000);

--- a/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/Code39BarCodeCommandTest.cs
+++ b/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/Code39BarCodeCommandTest.cs
@@ -1,0 +1,143 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+
+namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
+{
+    [TestClass]
+    public class Code39BarCodeCommandTest
+    {
+        [TestMethod]
+        public void ToZpl_Default1_Successful()
+        {
+            var command = new Code39BarCodeCommand();
+            var zplCommand = command.ToZpl();
+            Assert.AreEqual("^B3N,N,,Y,N", zplCommand);
+        }
+
+        [TestMethod]
+        public void ToZpl_Default2_Successful()
+        {
+            var command = new Code39BarCodeCommand(Orientation.Rotated180);
+            var zplCommand = command.ToZpl();
+            Assert.AreEqual("^B3I,N,,Y,N", zplCommand);
+        }
+
+        [TestMethod]
+        public void ToZpl_Default3_Successful()
+        {
+            var command = new Code39BarCodeCommand(barCodeHeight: 10);
+            var zplCommand = command.ToZpl();
+            Assert.AreEqual("^B3N,N,10,Y,N", zplCommand);
+        }
+
+        [TestMethod]
+        public void ToZpl_Default4_Successful()
+        {
+            var command = new Code39BarCodeCommand(printInterpretationLine: false, printInterpretationLineAboveCode: false, mod43CheckDigit: true);
+            var zplCommand = command.ToZpl();
+            Assert.AreEqual("^B3N,Y,,N,N", zplCommand);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException), "Must be between 1 and 32000")]
+        public void Constructor_InvalidBarCodeHeight1_Exception()
+        {
+            new Code39BarCodeCommand(barCodeHeight: 0);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException), "Must be between 1 and 32000")]
+        public void Constructor_InvalidBarCodeHeight2_Exception()
+        {
+            new Code39BarCodeCommand(barCodeHeight: 33000);
+        }
+
+        [TestMethod]
+        public void IsCommandParsable_ValidCommand_True()
+        {
+            var command = new Code39BarCodeCommand();
+            var isParsable = command.IsCommandParsable("^B3N,N,,Y,N");
+            Assert.IsTrue(isParsable);
+        }
+
+        [TestMethod]
+        public void IsCommandParsable_InvalidCommand_False()
+        {
+            var command = new Code39BarCodeCommand();
+            var isParsable = command.IsCommandParsable("^FT10,10");
+            Assert.IsFalse(isParsable);
+        }
+
+        [TestMethod]
+        public void ParseCommand_ValidCommand1_Successful()
+        {
+            var command = new Code39BarCodeCommand();
+            command.ParseCommand("^B3N,N,,Y,N");
+            Assert.AreEqual(Orientation.Normal, command.Orientation);
+            Assert.IsFalse(command.Mod43CheckDigit);
+            Assert.IsNull(command.BarCodeHeight);
+            Assert.IsTrue(command.PrintInterpretationLine);
+            Assert.IsFalse(command.PrintInterpretationLineAboveCode);
+        }
+
+        [TestMethod]
+        public void ParseCommand_ValidCommand2_Successful()
+        {
+            var command = new Code39BarCodeCommand();
+            command.ParseCommand("^B3N,N,,Y,Y");
+            Assert.AreEqual(Orientation.Normal, command.Orientation);
+            Assert.IsFalse(command.Mod43CheckDigit);
+            Assert.IsNull(command.BarCodeHeight);
+            Assert.IsTrue(command.PrintInterpretationLine);
+            Assert.IsTrue(command.PrintInterpretationLineAboveCode);
+        }
+
+        [TestMethod]
+        public void ParseCommand_ValidCommand3_Successful()
+        {
+            var command = new Code39BarCodeCommand();
+            command.ParseCommand("^B3N,N,,N,N");
+            Assert.AreEqual(Orientation.Normal, command.Orientation);
+            Assert.IsFalse(command.Mod43CheckDigit);
+            Assert.IsNull(command.BarCodeHeight);
+            Assert.IsFalse(command.PrintInterpretationLine);
+            Assert.IsFalse(command.PrintInterpretationLineAboveCode);
+        }
+
+        [TestMethod]
+        public void ParseCommand_ValidCommand4_Successful()
+        {
+            var command = new Code39BarCodeCommand();
+            command.ParseCommand("^B3R,N,20,N,N");
+            Assert.AreEqual(Orientation.Rotated90, command.Orientation);
+            Assert.IsFalse(command.Mod43CheckDigit);
+            Assert.AreEqual(command.BarCodeHeight, 20);
+            Assert.IsFalse(command.PrintInterpretationLine);
+            Assert.IsFalse(command.PrintInterpretationLineAboveCode);
+        }
+
+        [TestMethod]
+        public void ParseCommand_ValidCommand5_Successful()
+        {
+            var command = new Code39BarCodeCommand();
+            command.ParseCommand("^B3B,,55");
+            Assert.AreEqual(Orientation.Rotated270, command.Orientation);
+            Assert.IsFalse(command.Mod43CheckDigit);
+            Assert.AreEqual(command.BarCodeHeight, 55);
+            Assert.IsTrue(command.PrintInterpretationLine);
+            Assert.IsFalse(command.PrintInterpretationLineAboveCode);
+        }
+
+        [TestMethod]
+        public void ParseCommand_ValidCommand6_Successful()
+        {
+            var command = new Code39BarCodeCommand();
+            command.ParseCommand("^B3");
+            Assert.AreEqual(Orientation.Normal, command.Orientation);
+            Assert.IsFalse(command.Mod43CheckDigit);
+            Assert.IsNull(command.BarCodeHeight);
+            Assert.IsTrue(command.PrintInterpretationLine);
+            Assert.IsFalse(command.PrintInterpretationLineAboveCode);
+        }
+    }
+}

--- a/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/Code39BarCodeCommandTest.cs
+++ b/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/Code39BarCodeCommandTest.cs
@@ -39,14 +39,14 @@ namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
         }
 
         [TestMethod]
-        [ExpectedException(typeof(ArgumentException), "Must be between 1 and 32000")]
+        [ExpectedException(typeof(ArgumentException))]
         public void Constructor_InvalidBarCodeHeight1_Exception()
         {
             new Code39BarCodeCommand(barCodeHeight: 0);
         }
 
         [TestMethod]
-        [ExpectedException(typeof(ArgumentException), "Must be between 1 and 32000")]
+        [ExpectedException(typeof(ArgumentException))]
         public void Constructor_InvalidBarCodeHeight2_Exception()
         {
             new Code39BarCodeCommand(barCodeHeight: 33000);

--- a/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/Code39BarCodeCommandTest.cs
+++ b/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/Code39BarCodeCommandTest.cs
@@ -111,7 +111,7 @@ namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
             command.ParseCommand("^B3R,N,20,N,N");
             Assert.AreEqual(Orientation.Rotated90, command.Orientation);
             Assert.IsFalse(command.Mod43CheckDigit);
-            Assert.AreEqual(command.BarCodeHeight, 20);
+            Assert.AreEqual(20, command.BarCodeHeight);
             Assert.IsFalse(command.PrintInterpretationLine);
             Assert.IsFalse(command.PrintInterpretationLineAboveCode);
         }
@@ -123,7 +123,7 @@ namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
             command.ParseCommand("^B3B,,55");
             Assert.AreEqual(Orientation.Rotated270, command.Orientation);
             Assert.IsFalse(command.Mod43CheckDigit);
-            Assert.AreEqual(command.BarCodeHeight, 55);
+            Assert.AreEqual(55, command.BarCodeHeight);
             Assert.IsTrue(command.PrintInterpretationLine);
             Assert.IsFalse(command.PrintInterpretationLineAboveCode);
         }

--- a/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/CommentCommandTest.cs
+++ b/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/CommentCommandTest.cs
@@ -1,0 +1,56 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
+{
+    [TestClass]
+    public class CommentCommandTest
+    {
+        [TestMethod]
+        public void ToZpl_Default_Successful()
+        {
+            var command = new CommentCommand();
+            var zplCommand = command.ToZpl();
+            Assert.AreEqual("^FX", zplCommand);
+        }
+
+        [TestMethod]
+        public void ToZpl_DefaultWithComment_Successful()
+        {
+            var command = new CommentCommand("Test");
+            var zplCommand = command.ToZpl();
+            Assert.AreEqual("^FXTest", zplCommand);
+        }
+
+        [TestMethod]
+        public void IsCommandParsable_ValidCommand_True()
+        {
+            var command = new CommentCommand();
+            var isParsable = command.IsCommandParsable("^FXTest");
+            Assert.IsTrue(isParsable);
+        }
+
+        [TestMethod]
+        public void IsCommandParsable_InvalidCommand_False()
+        {
+            var command = new CommentCommand();
+            var isParsable = command.IsCommandParsable("^FT10,10");
+            Assert.IsFalse(isParsable);
+        }
+
+        [TestMethod]
+        public void ParseCommand_ValidCommand1_Successful()
+        {
+            var command = new CommentCommand();
+            command.ParseCommand("^FX");
+            Assert.AreEqual(string.Empty, command.NonPrintingComment);
+        }
+
+        [TestMethod]
+        public void ParseCommand_ValidCommand2_Successful()
+        {
+            var command = new CommentCommand();
+            command.ParseCommand("^FXtest");
+            Assert.AreEqual("test", command.NonPrintingComment);
+        }
+    }
+}

--- a/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/DownloadGraphicsCommandTest.cs
+++ b/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/DownloadGraphicsCommandTest.cs
@@ -79,7 +79,7 @@ namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
         {
             var command = new DownloadGraphicsCommand();
             command.ParseCommand("~DGR:TEST.GRF,10,5,0000FFFFFFFFFFFFFF00");
-            Assert.AreEqual("R:", command.DeviceToStoreImage);
+            Assert.AreEqual("R:", command.StorageDevice);
             Assert.AreEqual("TEST.GRF", command.ImageName);
             Assert.AreEqual(10, command.TotalNumberOfBytesInGraphic);
             Assert.AreEqual(5, command.NumberOfBytesPerRow);
@@ -91,7 +91,7 @@ namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
         {
             var command = new DownloadGraphicsCommand();
             command.ParseCommand("~DGR:,10,5,0000FFFFFFFFFFFFFF00");
-            Assert.AreEqual("R:", command.DeviceToStoreImage);
+            Assert.AreEqual("R:", command.StorageDevice);
             Assert.AreEqual("UNKNOWN.GRF", command.ImageName);
             Assert.AreEqual(10, command.TotalNumberOfBytesInGraphic);
             Assert.AreEqual(5, command.NumberOfBytesPerRow);
@@ -103,7 +103,7 @@ namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
         {
             var command = new DownloadGraphicsCommand();
             command.ParseCommand("~DGR:TEST.GRF");
-            Assert.AreEqual("R:", command.DeviceToStoreImage);
+            Assert.AreEqual("R:", command.StorageDevice);
             Assert.AreEqual("TEST.GRF", command.ImageName);
             Assert.AreEqual(0, command.TotalNumberOfBytesInGraphic);
             Assert.AreEqual(0, command.NumberOfBytesPerRow);

--- a/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/DownloadGraphicsCommandTest.cs
+++ b/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/DownloadGraphicsCommandTest.cs
@@ -1,0 +1,68 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
+{
+    [TestClass]
+    public class DownloadGraphicsCommandTest
+    {
+        [TestMethod]
+        public void ToZpl_Default1_Successful()
+        {
+            var command = new DownloadGraphicsCommand("R:", "TEST.GRF", 10, 5, "0000FFFFFFFFFFFFFF00");
+            var zplCommand = command.ToZpl();
+            Assert.AreEqual("~DGR:TEST.GRF,10,5,0000FFFFFFFFFFFFFF00", zplCommand);
+        }
+
+        [TestMethod]
+        public void IsCommandParsable_ValidCommand_True()
+        {
+            var command = new DownloadGraphicsCommand();
+            var isParsable = command.IsCommandParsable("~DGR:TEST.GRF,10,5,0000FFFFFFFFFFFFFF00");
+            Assert.IsTrue(isParsable);
+        }
+
+        [TestMethod]
+        public void IsCommandParsable_InvalidCommand_False()
+        {
+            var command = new DownloadGraphicsCommand();
+            var isParsable = command.IsCommandParsable("^FT10,10");
+            Assert.IsFalse(isParsable);
+        }
+
+        [TestMethod]
+        public void ParseCommand_ValidCommand1_Successful()
+        {
+            var command = new DownloadGraphicsCommand();
+            command.ParseCommand("~DGR:TEST.GRF,10,5,0000FFFFFFFFFFFFFF00");
+            Assert.AreEqual("R:", command.DeviceToStoreImage);
+            Assert.AreEqual("TEST.GRF", command.ImageName);
+            Assert.AreEqual(10, command.TotalNumberOfBytesInGraphic);
+            Assert.AreEqual(5, command.NumberOfBytesPerRow);
+            Assert.AreEqual("0000FFFFFFFFFFFFFF00", command.Data);
+        }
+
+        [TestMethod]
+        public void ParseCommand_ValidCommand2_Successful()
+        {
+            var command = new DownloadGraphicsCommand();
+            command.ParseCommand("~DGR:,10,5,0000FFFFFFFFFFFFFF00");
+            Assert.AreEqual("R:", command.DeviceToStoreImage);
+            Assert.AreEqual("UNKNOWN.GRF", command.ImageName);
+            Assert.AreEqual(10, command.TotalNumberOfBytesInGraphic);
+            Assert.AreEqual(5, command.NumberOfBytesPerRow);
+            Assert.AreEqual("0000FFFFFFFFFFFFFF00", command.Data);
+        }
+
+        [TestMethod]
+        public void ParseCommand_NoData_Successful()
+        {
+            var command = new DownloadGraphicsCommand();
+            command.ParseCommand("~DGR:TEST.GRF");
+            Assert.AreEqual("R:", command.DeviceToStoreImage);
+            Assert.AreEqual("TEST.GRF", command.ImageName);
+            Assert.AreEqual(0, command.TotalNumberOfBytesInGraphic);
+            Assert.AreEqual(0, command.NumberOfBytesPerRow);
+            Assert.IsNull(command.Data);
+        }
+    }
+}

--- a/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/DownloadGraphicsCommandTest.cs
+++ b/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/DownloadGraphicsCommandTest.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 
 namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
 {
@@ -11,6 +12,50 @@ namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
             var command = new DownloadGraphicsCommand("R:", "TEST.GRF", 10, 5, "0000FFFFFFFFFFFFFF00");
             var zplCommand = command.ToZpl();
             Assert.AreEqual("~DGR:TEST.GRF,10,5,0000FFFFFFFFFFFFFF00", zplCommand);
+        }
+
+        [TestMethod]
+        public void ToZpl_Default2_Successful()
+        {
+            var command = new DownloadGraphicsCommand("R:", "TEST", 10, 5, "0000FFFFFFFFFFFFFF00");
+            var zplCommand = command.ToZpl();
+            Assert.AreEqual("~DGR:TEST,10,5,0000FFFFFFFFFFFFFF00", zplCommand);
+        }
+
+        [TestMethod]
+        public void ToZpl_Default3_Successful()
+        {
+            var command = new DownloadGraphicsCommand("R:", "TEST", 0, 0, "0000FFFFFFFFFFFFFF00");
+            var zplCommand = command.ToZpl();
+            Assert.AreEqual("~DGR:TEST,0,0,0000FFFFFFFFFFFFFF00", zplCommand);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void Constructor_InvalidDeviceToStoreImage1_Exception()
+        {
+            new DownloadGraphicsCommand("R", "TEST", 10, 5, "0000FFFFFFFFFFFFFF00");
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void Constructor_InvalidDeviceToStoreImage2_Exception()
+        {
+            new DownloadGraphicsCommand("R2", "TEST", 10, 5, "0000FFFFFFFFFFFFFF00");
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void Constructor_InvalidDeviceToStoreImage3_Exception()
+        {
+            new DownloadGraphicsCommand("R2", "TEST", 10, 5, "0000FFFFFFFFFFFFFF00");
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void Constructor_InvalidDeviceToStoreImage4_Exception()
+        {
+            new DownloadGraphicsCommand("Z:", "TEST", 10, 5, "0000FFFFFFFFFFFFFF00");
         }
 
         [TestMethod]

--- a/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/DownloadObjectsCommandTest.cs
+++ b/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/DownloadObjectsCommandTest.cs
@@ -1,0 +1,88 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
+{
+    [TestClass]
+    public class DownloadObjectsCommandTest
+    {
+        [TestMethod]
+        public void ToZpl_Default_Successful()
+        {
+            var command = new DownloadObjectsCommand("R:", "TEST.PNG", 'P', "P", 4, 2, "ABCDEF00");
+            var zplCommand = command.ToZpl();
+            Assert.AreEqual("~DYR:TEST.PNG,P,P,4,2,ABCDEF00", zplCommand);
+        }
+
+        [TestMethod]
+        public void IsCommandParsable_ValidCommand_True()
+        {
+            var command = new DownloadObjectsCommand();
+            var isParsable = command.IsCommandParsable("~DYR:TEST.PNG,P,P,4,2,ABCDEF00");
+            Assert.IsTrue(isParsable);
+        }
+
+        [TestMethod]
+        public void IsCommandParsable_InvalidCommand_False()
+        {
+            var command = new DownloadObjectsCommand();
+            var isParsable = command.IsCommandParsable("^FT10,10");
+            Assert.IsFalse(isParsable);
+        }
+
+        [TestMethod]
+        public void ParseCommand_ValidCommand1_Successful()
+        {
+            var command = new DownloadObjectsCommand();
+            command.ParseCommand("~DYR:TEST.PNG,P,P,4,2,ABCDEF00");
+            Assert.AreEqual("R:", command.StorageDevice);
+            Assert.AreEqual("TEST.PNG", command.FileName);
+            Assert.AreEqual('P', command.FormatDownloadedInDataField);
+            Assert.AreEqual("P", command.ExtensionOfStoredFile);
+            Assert.AreEqual(4, command.TotalNumberOfBytesInFile);
+            Assert.AreEqual(2, command.TotalNumberOfBytesPerRow);
+            Assert.AreEqual("ABCDEF00", command.Data);
+        }
+
+        [TestMethod]
+        public void ParseCommand_ValidCommand2_Successful()
+        {
+            var command = new DownloadObjectsCommand();
+            command.ParseCommand("~DYR:,P,P,4,2,ABCDEF00");
+            Assert.AreEqual("R:", command.StorageDevice);
+            Assert.AreEqual("UNKNOWN", command.FileName);
+            Assert.AreEqual('P', command.FormatDownloadedInDataField);
+            Assert.AreEqual("P", command.ExtensionOfStoredFile);
+            Assert.AreEqual(4, command.TotalNumberOfBytesInFile);
+            Assert.AreEqual(2, command.TotalNumberOfBytesPerRow);
+            Assert.AreEqual("ABCDEF00", command.Data);
+        }
+
+        [TestMethod]
+        public void ParseCommand_InvalidCommand1_Successful()
+        {
+            var command = new DownloadObjectsCommand();
+            command.ParseCommand("~DYR:IMAGE2.PNG,P,P,4,2");
+            Assert.AreEqual("R:", command.StorageDevice);
+            Assert.AreEqual("IMAGE2.PNG", command.FileName);
+            Assert.AreEqual('P', command.FormatDownloadedInDataField);
+            Assert.AreEqual("P", command.ExtensionOfStoredFile);
+            Assert.AreEqual(4, command.TotalNumberOfBytesInFile);
+            Assert.AreEqual(2, command.TotalNumberOfBytesPerRow);
+            Assert.AreEqual(null, command.Data);
+        }
+
+        [TestMethod]
+        public void ParseCommand_InvalidCommand2_Successful()
+        {
+            var command = new DownloadObjectsCommand();
+            command.ParseCommand("~DYR:");
+            Assert.AreEqual("R:", command.StorageDevice);
+            Assert.AreEqual("UNKNOWN", command.FileName);
+            Assert.AreEqual(char.MinValue, command.FormatDownloadedInDataField);
+            Assert.AreEqual(null, command.ExtensionOfStoredFile);
+            Assert.AreEqual(0, command.TotalNumberOfBytesInFile);
+            Assert.AreEqual(0, command.TotalNumberOfBytesPerRow);
+            Assert.AreEqual(null, command.Data);
+        }
+    }
+}

--- a/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/FieldBlockCommandTest.cs
+++ b/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/FieldBlockCommandTest.cs
@@ -1,0 +1,105 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+
+namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
+{
+    [TestClass]
+    public class FieldBlockCommandTest
+    {
+        [TestMethod]
+        public void ToZpl_Default1_Successful()
+        {
+            var command = new FieldBlockCommand();
+            var zplCommand = command.ToZpl();
+            Assert.AreEqual("^FB0,1,0,L,0", zplCommand);
+        }
+
+        [TestMethod]
+        public void ToZpl_Default2_Successful()
+        {
+            var command = new FieldBlockCommand(10, 2, -5, TextJustification.Right, 5);
+            var zplCommand = command.ToZpl();
+            Assert.AreEqual("^FB10,2,-5,R,5", zplCommand);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void Constructor_MaximumNumberOfLinesInTextBlockMin_Exception()
+        {
+            new FieldBlockCommand(maximumNumberOfLinesInTextBlock: 0);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void Constructor_MaximumNumberOfLinesInTextBlockMax_Exception()
+        {
+            new FieldBlockCommand(maximumNumberOfLinesInTextBlock: 10000);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void Constructor_AddOrDeleteSpaceBetweenLinesMin_Exception()
+        {
+            new FieldBlockCommand(addOrDeleteSpaceBetweenLines: -10000);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void Constructor_AddOrDeleteSpaceBetweenLinesMax_Exception()
+        {
+            new FieldBlockCommand(addOrDeleteSpaceBetweenLines: 10000);
+        }
+
+        [TestMethod]
+        public void IsCommandParsable_ValidCommand_True()
+        {
+            var command = new FieldBlockCommand();
+            var isParsable = command.IsCommandParsable("^FB0,1,0,L,0");
+            Assert.IsTrue(isParsable);
+        }
+
+        [TestMethod]
+        public void IsCommandParsable_InvalidCommand_False()
+        {
+            var command = new FieldBlockCommand();
+            var isParsable = command.IsCommandParsable("^FO10,10");
+            Assert.IsFalse(isParsable);
+        }
+
+        [TestMethod]
+        public void ParseCommand_ValidCommand1_Successful()
+        {
+            var command = new FieldBlockCommand();
+            command.ParseCommand("^FB400,3,-2,C,4");
+            Assert.AreEqual(400, command.WidthOfTextBlockLine);
+            Assert.AreEqual(3, command.MaximumNumberOfLinesInTextBlock);
+            Assert.AreEqual(-2, command.AddOrDeleteSpaceBetweenLines);
+            Assert.AreEqual(TextJustification.Center, command.TextJustification);
+            Assert.AreEqual(4, command.HangingIndentOfTheSecondAndRemainingLines);
+        }
+
+        [TestMethod]
+        public void ParseCommand_ValidCommand2_Successful()
+        {
+            var command = new FieldBlockCommand();
+            command.ParseCommand("^FB500");
+            Assert.AreEqual(500, command.WidthOfTextBlockLine);
+            Assert.AreEqual(1, command.MaximumNumberOfLinesInTextBlock);
+            Assert.AreEqual(0, command.AddOrDeleteSpaceBetweenLines);
+            Assert.AreEqual(TextJustification.Left, command.TextJustification);
+            Assert.AreEqual(0, command.HangingIndentOfTheSecondAndRemainingLines);
+        }
+
+        [TestMethod]
+        public void ParseCommand_ValidCommand3_Successful()
+        {
+            var command = new FieldBlockCommand();
+            command.ParseCommand("^FB0,3,33");
+            Assert.AreEqual(0, command.WidthOfTextBlockLine);
+            Assert.AreEqual(3, command.MaximumNumberOfLinesInTextBlock);
+            Assert.AreEqual(33, command.AddOrDeleteSpaceBetweenLines);
+            Assert.AreEqual(TextJustification.Left, command.TextJustification);
+            Assert.AreEqual(0, command.HangingIndentOfTheSecondAndRemainingLines);
+        }
+    }
+}

--- a/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/FieldDataCommandTest.cs
+++ b/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/FieldDataCommandTest.cs
@@ -1,0 +1,56 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
+{
+    [TestClass]
+    public class FieldDataCommandTest
+    {
+        [TestMethod]
+        public void ToZpl_Default_Successful()
+        {
+            var command = new FieldDataCommand();
+            var zplCommand = command.ToZpl();
+            Assert.AreEqual("^FD", zplCommand);
+        }
+
+        [TestMethod]
+        public void ToZpl_DefaultWithData_Successful()
+        {
+            var command = new FieldDataCommand("Test");
+            var zplCommand = command.ToZpl();
+            Assert.AreEqual("^FDTest", zplCommand);
+        }
+
+        [TestMethod]
+        public void IsCommandParsable_ValidCommand_True()
+        {
+            var command = new FieldDataCommand();
+            var isParsable = command.IsCommandParsable("^FDTest");
+            Assert.IsTrue(isParsable);
+        }
+
+        [TestMethod]
+        public void IsCommandParsable_InvalidCommand_False()
+        {
+            var command = new FieldDataCommand();
+            var isParsable = command.IsCommandParsable("^FT10,10");
+            Assert.IsFalse(isParsable);
+        }
+
+        [TestMethod]
+        public void ParseCommand_ValidCommand1_Successful()
+        {
+            var command = new FieldDataCommand();
+            command.ParseCommand("^FD");
+            Assert.AreEqual(string.Empty, command.Data);
+        }
+
+        [TestMethod]
+        public void ParseCommand_ValidCommand2_Successful()
+        {
+            var command = new FieldDataCommand();
+            command.ParseCommand("^FDtest");
+            Assert.AreEqual("test", command.Data);
+        }
+    }
+}

--- a/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/FieldOriginCommandTest.cs
+++ b/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/FieldOriginCommandTest.cs
@@ -73,8 +73,8 @@ namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
         {
             var command = new FieldOriginCommand();
             command.ParseCommand("^FO10,10");
-            Assert.AreEqual(command.X, 10);
-            Assert.AreEqual(command.Y, 10);
+            Assert.AreEqual(10, command.X);
+            Assert.AreEqual(10, command.Y);
         }
 
         [TestMethod]
@@ -82,8 +82,8 @@ namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
         {
             var command = new FieldOriginCommand();
             command.ParseCommand("^FO0,20");
-            Assert.AreEqual(command.X, 0);
-            Assert.AreEqual(command.Y, 20);
+            Assert.AreEqual(0, command.X);
+            Assert.AreEqual(20, command.Y);
         }
 
         [TestMethod]
@@ -91,8 +91,8 @@ namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
         {
             var command = new FieldOriginCommand();
             command.ParseCommand("^FO,10");
-            Assert.AreEqual(command.X, 0);
-            Assert.AreEqual(command.Y, 10);
+            Assert.AreEqual(0, command.X);
+            Assert.AreEqual(10, command.Y);
         }
     }
 }

--- a/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/FieldOriginCommandTest.cs
+++ b/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/FieldOriginCommandTest.cs
@@ -39,14 +39,14 @@ namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
         }
 
         [TestMethod]
-        [ExpectedException(typeof(ArgumentException), "Must be between 0 and 32000")]
+        [ExpectedException(typeof(ArgumentException))]
         public void Constructor_XMinus10Y0_Exception()
         {
             new FieldOriginCommand(-10, 0);
         }
 
         [TestMethod]
-        [ExpectedException(typeof(ArgumentException), "Must be between 0 and 32000")]
+        [ExpectedException(typeof(ArgumentException))]
         public void Constructor_X0YMinus10_Exception()
         {
             new FieldOriginCommand(0, -10);

--- a/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/FieldOriginCommandTest.cs
+++ b/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/FieldOriginCommandTest.cs
@@ -1,0 +1,98 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+
+namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
+{
+    [TestClass]
+    public class FieldOriginCommandTest
+    {
+        [TestMethod]
+        public void ToZpl_X10Y10_Successful()
+        {
+            var command = new FieldOriginCommand(10, 10);
+            var zplCommand = command.ToZpl();
+            Assert.AreEqual("^FO10,10", zplCommand);
+        }
+
+        [TestMethod]
+        public void ToZpl_X0Y0_Successful()
+        {
+            var command = new FieldOriginCommand(0, 0);
+            var zplCommand = command.ToZpl();
+            Assert.AreEqual("^FO0,0", zplCommand);
+        }
+
+        [TestMethod]
+        public void ToZpl_XnullY10_Successful()
+        {
+            var command = new FieldOriginCommand(null, 10);
+            var zplCommand = command.ToZpl();
+            Assert.AreEqual("^FO0,10", zplCommand);
+        }
+
+        [TestMethod]
+        public void ToZpl_XnullYnull_Successful()
+        {
+            var command = new FieldOriginCommand(null, null);
+            var zplCommand = command.ToZpl();
+            Assert.AreEqual("^FO0,0", zplCommand);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException), "Must be between 0 and 32000")]
+        public void Constructor_XMinus10Y0_Exception()
+        {
+            new FieldOriginCommand(-10, 0);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException), "Must be between 0 and 32000")]
+        public void Constructor_X0YMinus10_Exception()
+        {
+            new FieldOriginCommand(0, -10);
+        }
+
+        [TestMethod]
+        public void IsCommandParsable_ValidCommand_True()
+        {
+            var command = new FieldOriginCommand();
+            var isParsable = command.IsCommandParsable("^FO10,10");
+            Assert.IsTrue(isParsable);
+        }
+
+        [TestMethod]
+        public void IsCommandParsable_InvalidCommand_False()
+        {
+            var command = new FieldOriginCommand();
+            var isParsable = command.IsCommandParsable("^FT10,10");
+            Assert.IsFalse(isParsable);
+        }
+
+        [TestMethod]
+        public void ParseCommand_ValidCommand1_Successful()
+        {
+            var command = new FieldOriginCommand();
+            command.ParseCommand("^FO10,10");
+            Assert.AreEqual(command.X, 10);
+            Assert.AreEqual(command.Y, 10);
+        }
+
+        [TestMethod]
+        public void ParseCommand_ValidCommand2_Successful()
+        {
+            var command = new FieldOriginCommand();
+            command.ParseCommand("^FO0,20");
+            Assert.AreEqual(command.X, 0);
+            Assert.AreEqual(command.Y, 20);
+        }
+
+        [TestMethod]
+        public void ParseCommand_ValidCommandXisEmpty_Successful()
+        {
+            var command = new FieldOriginCommand();
+            command.ParseCommand("^FO,10");
+            Assert.AreEqual(command.X, 0);
+            Assert.AreEqual(command.Y, 10);
+        }
+    }
+}

--- a/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/FieldReversePrintCommandTest.cs
+++ b/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/FieldReversePrintCommandTest.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
+{
+    [TestClass]
+    public class FieldReversePrintCommandTest
+    {
+        [TestMethod]
+        public void ToZpl_Default_Successful()
+        {
+            var command = new FieldReversePrintCommand();
+            var zplCommand = command.ToZpl();
+            Assert.AreEqual("^FR", zplCommand);
+        }
+
+        [TestMethod]
+        public void IsCommandParsable_ValidCommand_True()
+        {
+            var command = new FieldReversePrintCommand();
+            var isParsable = command.IsCommandParsable("^FR");
+            Assert.IsTrue(isParsable);
+        }
+
+        [TestMethod]
+        public void IsCommandParsable_InvalidCommand_False()
+        {
+            var command = new FieldReversePrintCommand();
+            var isParsable = command.IsCommandParsable("^FT10,10");
+            Assert.IsFalse(isParsable);
+        }
+
+        [TestMethod]
+        public void ParseCommand_ValidCommand1_Successful()
+        {
+            var command = new FieldReversePrintCommand();
+            command.ParseCommand("^FR");
+        }
+    }
+}

--- a/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/FieldSeperatorCommandTest.cs
+++ b/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/FieldSeperatorCommandTest.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
+{
+    [TestClass]
+    public class FieldSeperatorCommandTest
+    {
+        [TestMethod]
+        public void ToZpl_Default_Successful()
+        {
+            var command = new FieldSeperatorCommand();
+            var zplCommand = command.ToZpl();
+            Assert.AreEqual("^FS", zplCommand);
+        }
+
+        [TestMethod]
+        public void IsCommandParsable_ValidCommand_True()
+        {
+            var command = new FieldSeperatorCommand();
+            var isParsable = command.IsCommandParsable("^FS");
+            Assert.IsTrue(isParsable);
+        }
+
+        [TestMethod]
+        public void IsCommandParsable_InvalidCommand_False()
+        {
+            var command = new FieldSeperatorCommand();
+            var isParsable = command.IsCommandParsable("^FT10,10");
+            Assert.IsFalse(isParsable);
+        }
+
+        [TestMethod]
+        public void ParseCommand_ValidCommand1_Successful()
+        {
+            var command = new FieldSeperatorCommand();
+            command.ParseCommand("^FS");
+        }
+    }
+}

--- a/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/FieldTypesetCommandTest.cs
+++ b/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/FieldTypesetCommandTest.cs
@@ -39,14 +39,14 @@ namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
         }
 
         [TestMethod]
-        [ExpectedException(typeof(ArgumentException), "Must be between 0 and 32000")]
+        [ExpectedException(typeof(ArgumentException))]
         public void Constructor_XMinus10Y0_Exception()
         {
             new FieldTypesetCommand(-10, 0);
         }
 
         [TestMethod]
-        [ExpectedException(typeof(ArgumentException), "Must be between 0 and 32000")]
+        [ExpectedException(typeof(ArgumentException))]
         public void Constructor_X0YMinus10_Exception()
         {
             new FieldTypesetCommand(0, -10);

--- a/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/FieldTypesetCommandTest.cs
+++ b/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/FieldTypesetCommandTest.cs
@@ -1,0 +1,98 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+
+namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
+{
+    [TestClass]
+    public class FieldTypesetCommandTest
+    {
+        [TestMethod]
+        public void ToZpl_X10Y10_Successful()
+        {
+            var command = new FieldTypesetCommand(10, 10);
+            var zplCommand = command.ToZpl();
+            Assert.AreEqual("^FT10,10", zplCommand);
+        }
+
+        [TestMethod]
+        public void ToZpl_X0Y0_Successful()
+        {
+            var command = new FieldTypesetCommand(0, 0);
+            var zplCommand = command.ToZpl();
+            Assert.AreEqual("^FT0,0", zplCommand);
+        }
+
+        [TestMethod]
+        public void ToZpl_XnullY10_Successful()
+        {
+            var command = new FieldTypesetCommand(null, 10);
+            var zplCommand = command.ToZpl();
+            Assert.AreEqual("^FT0,10", zplCommand);
+        }
+
+        [TestMethod]
+        public void ToZpl_XnullYnull_Successful()
+        {
+            var command = new FieldTypesetCommand(null, null);
+            var zplCommand = command.ToZpl();
+            Assert.AreEqual("^FT0,0", zplCommand);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException), "Must be between 0 and 32000")]
+        public void Constructor_XMinus10Y0_Exception()
+        {
+            new FieldTypesetCommand(-10, 0);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException), "Must be between 0 and 32000")]
+        public void Constructor_X0YMinus10_Exception()
+        {
+            new FieldTypesetCommand(0, -10);
+        }
+
+        [TestMethod]
+        public void IsCommandParsable_ValidCommand_True()
+        {
+            var command = new FieldTypesetCommand();
+            var isParsable = command.IsCommandParsable("^FT10,10");
+            Assert.IsTrue(isParsable);
+        }
+
+        [TestMethod]
+        public void IsCommandParsable_InvalidCommand_False()
+        {
+            var command = new FieldTypesetCommand();
+            var isParsable = command.IsCommandParsable("^FO10,10");
+            Assert.IsFalse(isParsable);
+        }
+
+        [TestMethod]
+        public void ParseCommand_ValidCommand1_Successful()
+        {
+            var command = new FieldTypesetCommand();
+            command.ParseCommand("^FT10,10");
+            Assert.AreEqual(command.X, 10);
+            Assert.AreEqual(command.Y, 10);
+        }
+
+        [TestMethod]
+        public void ParseCommand_ValidCommand2_Successful()
+        {
+            var command = new FieldTypesetCommand();
+            command.ParseCommand("^FT0,20");
+            Assert.AreEqual(command.X, 0);
+            Assert.AreEqual(command.Y, 20);
+        }
+
+        [TestMethod]
+        public void ParseCommand_ValidCommandXisEmpty_Successful()
+        {
+            var command = new FieldTypesetCommand();
+            command.ParseCommand("^FT,10");
+            Assert.AreEqual(command.X, 0);
+            Assert.AreEqual(command.Y, 10);
+        }
+    }
+}

--- a/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/FieldTypesetCommandTest.cs
+++ b/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/FieldTypesetCommandTest.cs
@@ -73,8 +73,8 @@ namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
         {
             var command = new FieldTypesetCommand();
             command.ParseCommand("^FT10,10");
-            Assert.AreEqual(command.X, 10);
-            Assert.AreEqual(command.Y, 10);
+            Assert.AreEqual(10, command.X);
+            Assert.AreEqual(10, command.Y);
         }
 
         [TestMethod]
@@ -82,8 +82,8 @@ namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
         {
             var command = new FieldTypesetCommand();
             command.ParseCommand("^FT0,20");
-            Assert.AreEqual(command.X, 0);
-            Assert.AreEqual(command.Y, 20);
+            Assert.AreEqual(0, command.X);
+            Assert.AreEqual(20, command.Y);
         }
 
         [TestMethod]
@@ -91,8 +91,8 @@ namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
         {
             var command = new FieldTypesetCommand();
             command.ParseCommand("^FT,10");
-            Assert.AreEqual(command.X, 0);
-            Assert.AreEqual(command.Y, 10);
+            Assert.AreEqual(0, command.X);
+            Assert.AreEqual(10, command.Y);
         }
     }
 }

--- a/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/GraphicBoxCommandTest.cs
+++ b/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/GraphicBoxCommandTest.cs
@@ -39,14 +39,14 @@ namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
         }
 
         [TestMethod]
-        [ExpectedException(typeof(ArgumentException), "Must be between 1 and 32000")]
+        [ExpectedException(typeof(ArgumentException))]
         public void Constructor_WidthMinus10Height1_Exception()
         {
             new GraphicBoxCommand(-10, 1);
         }
 
         [TestMethod]
-        [ExpectedException(typeof(ArgumentException), "Must be between 1 and 32000")]
+        [ExpectedException(typeof(ArgumentException))]
         public void Constructor_Widht1HeightMinus10_Exception()
         {
             new GraphicBoxCommand(1, -10);

--- a/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/GraphicBoxCommandTest.cs
+++ b/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/GraphicBoxCommandTest.cs
@@ -81,8 +81,8 @@ namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
         {
             var command = new GraphicBoxCommand();
             command.ParseCommand("^GB10,10");
-            Assert.AreEqual(command.BoxWidth, 10);
-            Assert.AreEqual(command.BoxHeight, 10);
+            Assert.AreEqual(10, command.BoxWidth);
+            Assert.AreEqual(10, command.BoxHeight);
         }
 
         [TestMethod]
@@ -90,11 +90,11 @@ namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
         {
             var command = new GraphicBoxCommand();
             command.ParseCommand("^GB10,10,2,W,1");
-            Assert.AreEqual(command.BoxWidth, 10);
-            Assert.AreEqual(command.BoxHeight, 10);
-            Assert.AreEqual(command.BorderThickness, 2);
-            Assert.AreEqual(command.LineColor, LineColor.White);
-            Assert.AreEqual(command.DegreeOfCornerrounding, 1);
+            Assert.AreEqual(10, command.BoxWidth);
+            Assert.AreEqual(10, command.BoxHeight);
+            Assert.AreEqual(2, command.BorderThickness);
+            Assert.AreEqual(LineColor.White, command.LineColor);
+            Assert.AreEqual(1, command.DegreeOfCornerrounding);
         }
 
         [TestMethod]
@@ -102,11 +102,11 @@ namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
         {
             var command = new GraphicBoxCommand();
             command.ParseCommand("^GB10,10,2,,2");
-            Assert.AreEqual(command.BoxWidth, 10);
-            Assert.AreEqual(command.BoxHeight, 10);
-            Assert.AreEqual(command.BorderThickness, 2);
-            Assert.AreEqual(command.LineColor, LineColor.Black);
-            Assert.AreEqual(command.DegreeOfCornerrounding, 2);
+            Assert.AreEqual(10, command.BoxWidth);
+            Assert.AreEqual(10, command.BoxHeight);
+            Assert.AreEqual(2, command.BorderThickness);
+            Assert.AreEqual(LineColor.Black, command.LineColor);
+            Assert.AreEqual(2, command.DegreeOfCornerrounding);
         }
 
         [TestMethod]
@@ -114,9 +114,9 @@ namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
         {
             var command = new GraphicBoxCommand();
             command.ParseCommand("^GB10,10,20");
-            Assert.AreEqual(command.BoxWidth, 20);
-            Assert.AreEqual(command.BoxHeight, 20);
-            Assert.AreEqual(command.BorderThickness, 20);
+            Assert.AreEqual(20, command.BoxWidth);
+            Assert.AreEqual(20, command.BoxHeight);
+            Assert.AreEqual(20, command.BorderThickness);
         }
     }
 }

--- a/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/GraphicBoxCommandTest.cs
+++ b/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/GraphicBoxCommandTest.cs
@@ -1,0 +1,122 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+
+namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
+{
+    [TestClass]
+    public class GraphicBoxCommandTest
+    {
+        [TestMethod]
+        public void ToZpl_Width10Height10_Successful()
+        {
+            var command = new GraphicBoxCommand(10, 10);
+            var zplCommand = command.ToZpl();
+            Assert.AreEqual("^GB10,10,1,B,0", zplCommand);
+        }
+
+        [TestMethod]
+        public void ToZpl_Width1Height1_Successful()
+        {
+            var command = new GraphicBoxCommand(1, 1);
+            var zplCommand = command.ToZpl();
+            Assert.AreEqual("^GB1,1,1,B,0", zplCommand);
+        }
+
+        [TestMethod]
+        public void ToZpl_WidthNullHeight10_Successful()
+        {
+            var command = new GraphicBoxCommand(null, 10);
+            var zplCommand = command.ToZpl();
+            Assert.AreEqual("^GB1,10,1,B,0", zplCommand);
+        }
+
+        [TestMethod]
+        public void ToZpl_WidthNullHeightNull_Successful()
+        {
+            var command = new GraphicBoxCommand(null, null);
+            var zplCommand = command.ToZpl();
+            Assert.AreEqual("^GB1,1,1,B,0", zplCommand);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException), "Must be between 1 and 32000")]
+        public void Constructor_WidthMinus10Height1_Exception()
+        {
+            new GraphicBoxCommand(-10, 1);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException), "Must be between 1 and 32000")]
+        public void Constructor_Widht1HeightMinus10_Exception()
+        {
+            new GraphicBoxCommand(1, -10);
+        }
+
+        [TestMethod]
+        public void IsCommandParsable_ValidCommand1_True()
+        {
+            var command = new GraphicBoxCommand();
+            var isParsable = command.IsCommandParsable("^GB10,10");
+            Assert.IsTrue(isParsable);
+        }
+
+        [TestMethod]
+        public void IsCommandParsable_ValidCommand2_True()
+        {
+            var command = new GraphicBoxCommand();
+            var isParsable = command.IsCommandParsable("^GB10,10,1,W,1");
+            Assert.IsTrue(isParsable);
+        }
+
+        [TestMethod]
+        public void IsCommandParsable_InvalidCommand_False()
+        {
+            var command = new GraphicBoxCommand();
+            var isParsable = command.IsCommandParsable("^FT10,10");
+            Assert.IsFalse(isParsable);
+        }
+
+        [TestMethod]
+        public void ParseCommand_ValidCommand1_Successful()
+        {
+            var command = new GraphicBoxCommand();
+            command.ParseCommand("^GB10,10");
+            Assert.AreEqual(command.BoxWidth, 10);
+            Assert.AreEqual(command.BoxHeight, 10);
+        }
+
+        [TestMethod]
+        public void ParseCommand_ValidCommand2_Successful()
+        {
+            var command = new GraphicBoxCommand();
+            command.ParseCommand("^GB10,10,2,W,1");
+            Assert.AreEqual(command.BoxWidth, 10);
+            Assert.AreEqual(command.BoxHeight, 10);
+            Assert.AreEqual(command.BorderThickness, 2);
+            Assert.AreEqual(command.LineColor, LineColor.White);
+            Assert.AreEqual(command.DegreeOfCornerrounding, 1);
+        }
+
+        [TestMethod]
+        public void ParseCommand_ValidCommand3_Successful()
+        {
+            var command = new GraphicBoxCommand();
+            command.ParseCommand("^GB10,10,2,,2");
+            Assert.AreEqual(command.BoxWidth, 10);
+            Assert.AreEqual(command.BoxHeight, 10);
+            Assert.AreEqual(command.BorderThickness, 2);
+            Assert.AreEqual(command.LineColor, LineColor.Black);
+            Assert.AreEqual(command.DegreeOfCornerrounding, 2);
+        }
+
+        [TestMethod]
+        public void ParseCommand_ValidCommand4_Successful()
+        {
+            var command = new GraphicBoxCommand();
+            command.ParseCommand("^GB10,10,20");
+            Assert.AreEqual(command.BoxWidth, 20);
+            Assert.AreEqual(command.BoxHeight, 20);
+            Assert.AreEqual(command.BorderThickness, 20);
+        }
+    }
+}

--- a/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/GraphicCircleCommandTest.cs
+++ b/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/GraphicCircleCommandTest.cs
@@ -73,8 +73,8 @@ namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
         {
             var command = new GraphicCircleCommand();
             command.ParseCommand("^GC10,5");
-            Assert.AreEqual(command.CircleDiameter, 10);
-            Assert.AreEqual(command.BorderThickness, 5);
+            Assert.AreEqual(10, command.CircleDiameter);
+            Assert.AreEqual(5, command.BorderThickness);
         }
 
         [TestMethod]
@@ -82,9 +82,9 @@ namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
         {
             var command = new GraphicCircleCommand();
             command.ParseCommand("^GC,2,W");
-            Assert.AreEqual(command.CircleDiameter, 3);
-            Assert.AreEqual(command.BorderThickness, 2);
-            Assert.AreEqual(command.LineColor, LineColor.White);
+            Assert.AreEqual(3, command.CircleDiameter);
+            Assert.AreEqual(2, command.BorderThickness);
+            Assert.AreEqual(LineColor.White, command.LineColor);
         }
 
         [TestMethod]
@@ -92,9 +92,9 @@ namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
         {
             var command = new GraphicCircleCommand();
             command.ParseCommand("^GC,,W");
-            Assert.AreEqual(command.CircleDiameter, 3);
-            Assert.AreEqual(command.BorderThickness, 1);
-            Assert.AreEqual(command.LineColor, LineColor.White);
+            Assert.AreEqual(3, command.CircleDiameter);
+            Assert.AreEqual(1, command.BorderThickness);
+            Assert.AreEqual(LineColor.White, command.LineColor);
         }
     }
 }

--- a/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/GraphicCircleCommandTest.cs
+++ b/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/GraphicCircleCommandTest.cs
@@ -1,0 +1,100 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+
+namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
+{
+    [TestClass]
+    public class GraphicCircleCommandTest
+    {
+        [TestMethod]
+        public void ToZpl_DefaulValues1_Successful()
+        {
+            var command = new GraphicCircleCommand(10);
+            var zplCommand = command.ToZpl();
+            Assert.AreEqual("^GC10,1,B", zplCommand);
+        }
+
+        [TestMethod]
+        public void ToZpl_DefaulValues2_Successful()
+        {
+            var command = new GraphicCircleCommand(10, 5);
+            var zplCommand = command.ToZpl();
+            Assert.AreEqual("^GC10,5,B", zplCommand);
+        }
+
+        [TestMethod]
+        public void ToZpl_DefaulValues3_Successful()
+        {
+            var command = new GraphicCircleCommand(10, 5, LineColor.White);
+            var zplCommand = command.ToZpl();
+            Assert.AreEqual("^GC10,5,W", zplCommand);
+        }
+
+        [TestMethod]
+        public void ToZpl_DefaulValues4_Successful()
+        {
+            var command = new GraphicCircleCommand(null, 5, LineColor.White);
+            var zplCommand = command.ToZpl();
+            Assert.AreEqual("^GC3,5,W", zplCommand);
+        }
+
+        [TestMethod]
+        public void ToZpl_DefaulValues5_Successful()
+        {
+            var command = new GraphicCircleCommand(null, null, LineColor.White);
+            var zplCommand = command.ToZpl();
+            Assert.AreEqual("^GC3,1,W", zplCommand);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException), "Must be between 3 and 4095")]
+        public void Constructor_InvalidCircleDiameter_Exception()
+        {
+            new GraphicCircleCommand(1);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException), "Must be between 1 and 4095")]
+        public void Constructor_InvalidBorderThickness_Exception()
+        {
+            new GraphicCircleCommand(3, 5000);
+        }
+
+        [TestMethod]
+        public void IsCommandParsable_InvalidCommand_False()
+        {
+            var command = new GraphicCircleCommand();
+            var isParsable = command.IsCommandParsable("^FT10,10");
+            Assert.IsFalse(isParsable);
+        }
+
+        [TestMethod]
+        public void ParseCommand_ValidCommand1_Successful()
+        {
+            var command = new GraphicCircleCommand();
+            command.ParseCommand("^GC10,5");
+            Assert.AreEqual(command.CircleDiameter, 10);
+            Assert.AreEqual(command.BorderThickness, 5);
+        }
+
+        [TestMethod]
+        public void ParseCommand_ValidCommand2_Successful()
+        {
+            var command = new GraphicCircleCommand();
+            command.ParseCommand("^GC,2,W");
+            Assert.AreEqual(command.CircleDiameter, 3);
+            Assert.AreEqual(command.BorderThickness, 2);
+            Assert.AreEqual(command.LineColor, LineColor.White);
+        }
+
+        [TestMethod]
+        public void ParseCommand_ValidCommand3_Successful()
+        {
+            var command = new GraphicCircleCommand();
+            command.ParseCommand("^GC,,W");
+            Assert.AreEqual(command.CircleDiameter, 3);
+            Assert.AreEqual(command.BorderThickness, 1);
+            Assert.AreEqual(command.LineColor, LineColor.White);
+        }
+    }
+}

--- a/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/GraphicCircleCommandTest.cs
+++ b/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/GraphicCircleCommandTest.cs
@@ -47,14 +47,14 @@ namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
         }
 
         [TestMethod]
-        [ExpectedException(typeof(ArgumentException), "Must be between 3 and 4095")]
+        [ExpectedException(typeof(ArgumentException))]
         public void Constructor_InvalidCircleDiameter_Exception()
         {
             new GraphicCircleCommand(1);
         }
 
         [TestMethod]
-        [ExpectedException(typeof(ArgumentException), "Must be between 1 and 4095")]
+        [ExpectedException(typeof(ArgumentException))]
         public void Constructor_InvalidBorderThickness_Exception()
         {
             new GraphicCircleCommand(3, 5000);

--- a/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/GraphicFieldCommandTest.cs
+++ b/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/GraphicFieldCommandTest.cs
@@ -1,0 +1,127 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+
+namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
+{
+    [TestClass]
+    public class GraphicFieldCommandTest
+    {
+        [TestMethod]
+        public void ToZpl_Default1_Successful()
+        {
+            var command = new GraphicFieldCommand();
+            var zplCommand = command.ToZpl();
+            Assert.AreEqual("^GFA,0,0,0,", zplCommand);
+        }
+
+        [TestMethod]
+        public void ToZpl_Default2_Successful()
+        {
+            var command = new GraphicFieldCommand('A', 1, 1, 1, "AB");
+            var zplCommand = command.ToZpl();
+            Assert.AreEqual("^GFA,1,1,1,AB", zplCommand);
+        }
+
+        [TestMethod]
+        public void ToZpl_Default3_Successful()
+        {
+            var command = new GraphicFieldCommand('A', 4, 4, 2, "A1B2C3D4");
+            var zplCommand = command.ToZpl();
+            Assert.AreEqual("^GFA,4,4,2,A1B2C3D4", zplCommand);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void Constructor_BinaryByteCountTooLow_Exception()
+        {
+            new GraphicFieldCommand('A', 0, 1, 1, "AB");
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void Constructor_BinaryByteCountTooHigh_Exception()
+        {
+            new GraphicFieldCommand('A', 100000, 1, 1, "AB");
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void Constructor_GraphicFieldCountTooLow_Exception()
+        {
+            new GraphicFieldCommand('A', 1, 0, 1, "AB");
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void Constructor_GraphicFieldCountTooHigh_Exception()
+        {
+            new GraphicFieldCommand('A', 1, 100000, 1, "AB");
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void Constructor_BytesPerRowTooLow_Exception()
+        {
+            new GraphicFieldCommand('A', 1, 1, 0, "AB");
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void Constructor_BytesPerRowTooHigh_Exception()
+        {
+            new GraphicFieldCommand('A', 1, 1, 100000, "AB");
+        }
+
+        [TestMethod]
+        public void IsCommandParsable_ValidCommand_True()
+        {
+            var command = new GraphicFieldCommand();
+            var isParsable = command.IsCommandParsable("^GFA,4,4,2,A1B2C3D4");
+            Assert.IsTrue(isParsable);
+        }
+
+        [TestMethod]
+        public void IsCommandParsable_InvalidCommand_False()
+        {
+            var command = new GraphicFieldCommand();
+            var isParsable = command.IsCommandParsable("^FT10,10");
+            Assert.IsFalse(isParsable);
+        }
+
+        [TestMethod]
+        public void ParseCommand_ValidCommand1_Successful()
+        {
+            var command = new GraphicFieldCommand();
+            command.ParseCommand("^GFA,4,4,2,A1B2C3D4");
+            Assert.AreEqual('A', command.CompressionType);
+            Assert.AreEqual(4, command.BinaryByteCount);
+            Assert.AreEqual(4, command.GraphicFieldCount);
+            Assert.AreEqual(2, command.BytesPerRow);
+            Assert.AreEqual("A1B2C3D4", command.Data);
+        }
+
+        [TestMethod]
+        public void ParseCommand_ValidCommand2_Successful()
+        {
+            var command = new GraphicFieldCommand();
+            command.ParseCommand("^GFB,4,4,,A1B2C3D4");
+            Assert.AreEqual('B', command.CompressionType);
+            Assert.AreEqual(4, command.BinaryByteCount);
+            Assert.AreEqual(4, command.GraphicFieldCount);
+            Assert.AreEqual(0, command.BytesPerRow);
+            Assert.AreEqual("A1B2C3D4", command.Data);
+        }
+
+        [TestMethod]
+        public void ParseCommand_ValidCommand3_Successful()
+        {
+            var command = new GraphicFieldCommand();
+            command.ParseCommand("^GFB,,,,A1B2C3D4");
+            Assert.AreEqual('B', command.CompressionType);
+            Assert.AreEqual(0, command.BinaryByteCount);
+            Assert.AreEqual(0, command.GraphicFieldCount);
+            Assert.AreEqual(0, command.BytesPerRow);
+            Assert.AreEqual("A1B2C3D4", command.Data);
+        }
+    }
+}

--- a/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/ImageMoveCommandTest.cs
+++ b/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/ImageMoveCommandTest.cs
@@ -1,0 +1,68 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+
+namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
+{
+    [TestClass]
+    public class ImageMoveCommandTest
+    {
+        [TestMethod]
+        public void ToZpl_Default1_Successful()
+        {
+            var command = new ImageMoveCommand("R:", "TEST.GRF");
+            var zplCommand = command.ToZpl();
+            Assert.AreEqual("^IMR:TEST.GRF", zplCommand);
+        }
+
+        [TestMethod]
+        public void ToZpl_Default2_Successful()
+        {
+            var command = new ImageMoveCommand("R:", "TEST.PNG");
+            var zplCommand = command.ToZpl();
+            Assert.AreEqual("^IMR:TEST.PNG", zplCommand);
+        }
+
+        [TestMethod]
+        public void IsCommandParsable_ValidCommand_True()
+        {
+            var command = new ImageMoveCommand();
+            var isParsable = command.IsCommandParsable("^IMR:TEST.PNG");
+            Assert.IsTrue(isParsable);
+        }
+
+        [TestMethod]
+        public void IsCommandParsable_InvalidCommand_False()
+        {
+            var command = new ImageMoveCommand();
+            var isParsable = command.IsCommandParsable("^FT10,10");
+            Assert.IsFalse(isParsable);
+        }
+
+        [TestMethod]
+        public void ParseCommand_ValidCommand1_Successful()
+        {
+            var command = new ImageMoveCommand();
+            command.ParseCommand("^IMR:TEST.PNG");
+            Assert.AreEqual("R:", command.LocationOfStoredObject);
+            Assert.AreEqual("TEST.PNG", command.ImageName);
+        }
+
+        [TestMethod]
+        public void ParseCommand_ValidCommand2_Successful()
+        {
+            var command = new ImageMoveCommand();
+            command.ParseCommand("^IMR:IMAGE.GRF");
+            Assert.AreEqual("R:", command.LocationOfStoredObject);
+            Assert.AreEqual("IMAGE.GRF", command.ImageName);
+        }
+
+        [TestMethod]
+        public void ParseCommand_ValidCommand3_Successful()
+        {
+            var command = new ImageMoveCommand();
+            command.ParseCommand("^IMR:");
+            Assert.AreEqual("R:", command.LocationOfStoredObject);
+            Assert.AreEqual("UNKNOWN.GRF", command.ImageName);
+        }
+    }
+}

--- a/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/ImageMoveCommandTest.cs
+++ b/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/ImageMoveCommandTest.cs
@@ -43,7 +43,7 @@ namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
         {
             var command = new ImageMoveCommand();
             command.ParseCommand("^IMR:TEST.PNG");
-            Assert.AreEqual("R:", command.LocationOfStoredObject);
+            Assert.AreEqual("R:", command.StorageDevice);
             Assert.AreEqual("TEST.PNG", command.ImageName);
         }
 
@@ -52,7 +52,7 @@ namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
         {
             var command = new ImageMoveCommand();
             command.ParseCommand("^IMR:IMAGE.GRF");
-            Assert.AreEqual("R:", command.LocationOfStoredObject);
+            Assert.AreEqual("R:", command.StorageDevice);
             Assert.AreEqual("IMAGE.GRF", command.ImageName);
         }
 
@@ -61,7 +61,7 @@ namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
         {
             var command = new ImageMoveCommand();
             command.ParseCommand("^IMR:");
-            Assert.AreEqual("R:", command.LocationOfStoredObject);
+            Assert.AreEqual("R:", command.StorageDevice);
             Assert.AreEqual("UNKNOWN.GRF", command.ImageName);
         }
     }

--- a/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/Interleaved2Of5BarCodeCommandTest.cs
+++ b/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/Interleaved2Of5BarCodeCommandTest.cs
@@ -1,0 +1,143 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+
+namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
+{
+    [TestClass]
+    public class Interleaved2Of5BarCodeCommandTest
+    {
+        [TestMethod]
+        public void ToZpl_Default1_Successful()
+        {
+            var command = new Interleaved2Of5BarCodeCommand();
+            var zplCommand = command.ToZpl();
+            Assert.AreEqual("^B2N,,Y,N,N", zplCommand);
+        }
+
+        [TestMethod]
+        public void ToZpl_Default2_Successful()
+        {
+            var command = new Interleaved2Of5BarCodeCommand(Orientation.Rotated180);
+            var zplCommand = command.ToZpl();
+            Assert.AreEqual("^B2I,,Y,N,N", zplCommand);
+        }
+
+        [TestMethod]
+        public void ToZpl_Default3_Successful()
+        {
+            var command = new Interleaved2Of5BarCodeCommand(barCodeHeight: 10);
+            var zplCommand = command.ToZpl();
+            Assert.AreEqual("^B2N,10,Y,N,N", zplCommand);
+        }
+
+        [TestMethod]
+        public void ToZpl_Default4_Successful()
+        {
+            var command = new Interleaved2Of5BarCodeCommand(printInterpretationLine: false, printInterpretationLineAboveCode: false, calculateAndPrintMod10CheckDigit: true);
+            var zplCommand = command.ToZpl();
+            Assert.AreEqual("^B2N,,N,N,Y", zplCommand);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException), "Must be between 1 and 32000")]
+        public void Constructor_InvalidBarCodeHeight1_Exception()
+        {
+            new Interleaved2Of5BarCodeCommand(barCodeHeight: 0);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException), "Must be between 1 and 32000")]
+        public void Constructor_InvalidBarCodeHeight2_Exception()
+        {
+            new Interleaved2Of5BarCodeCommand(barCodeHeight: 33000);
+        }
+
+        [TestMethod]
+        public void IsCommandParsable_ValidCommand_True()
+        {
+            var command = new Interleaved2Of5BarCodeCommand();
+            var isParsable = command.IsCommandParsable("^B2N,,N,N,Y");
+            Assert.IsTrue(isParsable);
+        }
+
+        [TestMethod]
+        public void IsCommandParsable_InvalidCommand_False()
+        {
+            var command = new Interleaved2Of5BarCodeCommand();
+            var isParsable = command.IsCommandParsable("^FT10,10");
+            Assert.IsFalse(isParsable);
+        }
+
+        [TestMethod]
+        public void ParseCommand_ValidCommand1_Successful()
+        {
+            var command = new Interleaved2Of5BarCodeCommand();
+            command.ParseCommand("^B2N,,N,N,Y");
+            Assert.AreEqual(Orientation.Normal, command.Orientation);
+            Assert.IsNull(command.BarCodeHeight);
+            Assert.IsFalse(command.PrintInterpretationLine);
+            Assert.IsFalse(command.PrintInterpretationLineAboveCode);
+            Assert.IsTrue(command.CalculateAndPrintMod10CheckDigit);
+        }
+
+        [TestMethod]
+        public void ParseCommand_ValidCommand2_Successful()
+        {
+            var command = new Interleaved2Of5BarCodeCommand();
+            command.ParseCommand("^B2N,,Y,Y,Y");
+            Assert.AreEqual(Orientation.Normal, command.Orientation);
+            Assert.IsNull(command.BarCodeHeight);
+            Assert.IsTrue(command.PrintInterpretationLine);
+            Assert.IsTrue(command.PrintInterpretationLineAboveCode);
+            Assert.IsTrue(command.CalculateAndPrintMod10CheckDigit);
+        }
+
+        [TestMethod]
+        public void ParseCommand_ValidCommand3_Successful()
+        {
+            var command = new Interleaved2Of5BarCodeCommand();
+            command.ParseCommand("^B2N,,N,N,N");
+            Assert.AreEqual(Orientation.Normal, command.Orientation);
+            Assert.IsNull(command.BarCodeHeight);
+            Assert.IsFalse(command.PrintInterpretationLine);
+            Assert.IsFalse(command.PrintInterpretationLineAboveCode);
+            Assert.IsFalse(command.CalculateAndPrintMod10CheckDigit);
+        }
+
+        [TestMethod]
+        public void ParseCommand_ValidCommand4_Successful()
+        {
+            var command = new Interleaved2Of5BarCodeCommand();
+            command.ParseCommand("^B2R,20,N,N,N");
+            Assert.AreEqual(Orientation.Rotated90, command.Orientation);
+            Assert.AreEqual(command.BarCodeHeight, 20);
+            Assert.IsFalse(command.PrintInterpretationLine);
+            Assert.IsFalse(command.PrintInterpretationLineAboveCode);
+            Assert.IsFalse(command.CalculateAndPrintMod10CheckDigit);
+        }
+
+        [TestMethod]
+        public void ParseCommand_ValidCommand5_Successful()
+        {
+            var command = new Interleaved2Of5BarCodeCommand();
+            command.ParseCommand("^B2B,55");
+            Assert.AreEqual(Orientation.Rotated270, command.Orientation);
+            Assert.AreEqual(command.BarCodeHeight, 55);
+            Assert.IsTrue(command.PrintInterpretationLine);
+            Assert.IsFalse(command.PrintInterpretationLineAboveCode);
+            Assert.IsFalse(command.CalculateAndPrintMod10CheckDigit);
+        }
+
+        [TestMethod]
+        public void ParseCommand_ValidCommand6_Successful()
+        {
+            var command = new Interleaved2Of5BarCodeCommand();
+            command.ParseCommand("^B2");
+            Assert.AreEqual(Orientation.Normal, command.Orientation);
+            Assert.IsNull(command.BarCodeHeight);
+            Assert.IsTrue(command.PrintInterpretationLine);
+            Assert.IsFalse(command.PrintInterpretationLineAboveCode);
+            Assert.IsFalse(command.CalculateAndPrintMod10CheckDigit);
+        }
+    }
+}

--- a/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/Interleaved2Of5BarCodeCommandTest.cs
+++ b/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/Interleaved2Of5BarCodeCommandTest.cs
@@ -110,7 +110,7 @@ namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
             var command = new Interleaved2Of5BarCodeCommand();
             command.ParseCommand("^B2R,20,N,N,N");
             Assert.AreEqual(Orientation.Rotated90, command.Orientation);
-            Assert.AreEqual(command.BarCodeHeight, 20);
+            Assert.AreEqual(20, command.BarCodeHeight);
             Assert.IsFalse(command.PrintInterpretationLine);
             Assert.IsFalse(command.PrintInterpretationLineAboveCode);
             Assert.IsFalse(command.CalculateAndPrintMod10CheckDigit);
@@ -122,7 +122,7 @@ namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
             var command = new Interleaved2Of5BarCodeCommand();
             command.ParseCommand("^B2B,55");
             Assert.AreEqual(Orientation.Rotated270, command.Orientation);
-            Assert.AreEqual(command.BarCodeHeight, 55);
+            Assert.AreEqual(55, command.BarCodeHeight);
             Assert.IsTrue(command.PrintInterpretationLine);
             Assert.IsFalse(command.PrintInterpretationLineAboveCode);
             Assert.IsFalse(command.CalculateAndPrintMod10CheckDigit);

--- a/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/Interleaved2Of5BarCodeCommandTest.cs
+++ b/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/Interleaved2Of5BarCodeCommandTest.cs
@@ -39,14 +39,14 @@ namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
         }
 
         [TestMethod]
-        [ExpectedException(typeof(ArgumentException), "Must be between 1 and 32000")]
+        [ExpectedException(typeof(ArgumentException))]
         public void Constructor_InvalidBarCodeHeight1_Exception()
         {
             new Interleaved2Of5BarCodeCommand(barCodeHeight: 0);
         }
 
         [TestMethod]
-        [ExpectedException(typeof(ArgumentException), "Must be between 1 and 32000")]
+        [ExpectedException(typeof(ArgumentException))]
         public void Constructor_InvalidBarCodeHeight2_Exception()
         {
             new Interleaved2Of5BarCodeCommand(barCodeHeight: 33000);

--- a/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/LabelHomeCommandTest.cs
+++ b/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/LabelHomeCommandTest.cs
@@ -73,8 +73,8 @@ namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
         {
             var command = new LabelHomeCommand();
             command.ParseCommand("^LH10,10");
-            Assert.AreEqual(command.X, 10);
-            Assert.AreEqual(command.Y, 10);
+            Assert.AreEqual(10, command.X);
+            Assert.AreEqual(10, command.Y);
         }
 
         [TestMethod]
@@ -82,8 +82,8 @@ namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
         {
             var command = new LabelHomeCommand();
             command.ParseCommand("^LH0,20");
-            Assert.AreEqual(command.X, 0);
-            Assert.AreEqual(command.Y, 20);
+            Assert.AreEqual(0, command.X);
+            Assert.AreEqual(20, command.Y);
         }
 
         [TestMethod]
@@ -91,8 +91,8 @@ namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
         {
             var command = new LabelHomeCommand();
             command.ParseCommand("^LH,10");
-            Assert.AreEqual(command.X, 0);
-            Assert.AreEqual(command.Y, 10);
+            Assert.AreEqual(0, command.X);
+            Assert.AreEqual(10, command.Y);
         }
     }
 }

--- a/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/LabelHomeCommandTest.cs
+++ b/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/LabelHomeCommandTest.cs
@@ -1,0 +1,98 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+
+namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
+{
+    [TestClass]
+    public class LabelHomeCommandTest
+    {
+        [TestMethod]
+        public void ToZpl_X10Y10_Successful()
+        {
+            var command = new LabelHomeCommand(10, 10);
+            var zplCommand = command.ToZpl();
+            Assert.AreEqual("^LH10,10", zplCommand);
+        }
+
+        [TestMethod]
+        public void ToZpl_X0Y0_Successful()
+        {
+            var command = new LabelHomeCommand(0, 0);
+            var zplCommand = command.ToZpl();
+            Assert.AreEqual("^LH0,0", zplCommand);
+        }
+
+        [TestMethod]
+        public void ToZpl_XnullY10_Successful()
+        {
+            var command = new LabelHomeCommand(null, 10);
+            var zplCommand = command.ToZpl();
+            Assert.AreEqual("^LH0,10", zplCommand);
+        }
+
+        [TestMethod]
+        public void ToZpl_XnullYnull_Successful()
+        {
+            var command = new LabelHomeCommand(null, null);
+            var zplCommand = command.ToZpl();
+            Assert.AreEqual("^LH0,0", zplCommand);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException), "Must be between 0 and 32000")]
+        public void Constructor_XMinus10Y0_Exception()
+        {
+            new LabelHomeCommand(-10, 0);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException), "Must be between 0 and 32000")]
+        public void Constructor_X0YMinus10_Exception()
+        {
+            new LabelHomeCommand(0, -10);
+        }
+
+        [TestMethod]
+        public void IsCommandParsable_ValidCommand_True()
+        {
+            var command = new LabelHomeCommand();
+            var isParsable = command.IsCommandParsable("^LH10,10");
+            Assert.IsTrue(isParsable);
+        }
+
+        [TestMethod]
+        public void IsCommandParsable_InvalidCommand_False()
+        {
+            var command = new LabelHomeCommand();
+            var isParsable = command.IsCommandParsable("^FT10,10");
+            Assert.IsFalse(isParsable);
+        }
+
+        [TestMethod]
+        public void ParseCommand_ValidCommand1_Successful()
+        {
+            var command = new LabelHomeCommand();
+            command.ParseCommand("^LH10,10");
+            Assert.AreEqual(command.X, 10);
+            Assert.AreEqual(command.Y, 10);
+        }
+
+        [TestMethod]
+        public void ParseCommand_ValidCommand2_Successful()
+        {
+            var command = new LabelHomeCommand();
+            command.ParseCommand("^LH0,20");
+            Assert.AreEqual(command.X, 0);
+            Assert.AreEqual(command.Y, 20);
+        }
+
+        [TestMethod]
+        public void ParseCommand_ValidCommandXisEmpty_Successful()
+        {
+            var command = new LabelHomeCommand();
+            command.ParseCommand("^LH,10");
+            Assert.AreEqual(command.X, 0);
+            Assert.AreEqual(command.Y, 10);
+        }
+    }
+}

--- a/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/LabelHomeCommandTest.cs
+++ b/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/LabelHomeCommandTest.cs
@@ -39,14 +39,14 @@ namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
         }
 
         [TestMethod]
-        [ExpectedException(typeof(ArgumentException), "Must be between 0 and 32000")]
+        [ExpectedException(typeof(ArgumentException))]
         public void Constructor_XMinus10Y0_Exception()
         {
             new LabelHomeCommand(-10, 0);
         }
 
         [TestMethod]
-        [ExpectedException(typeof(ArgumentException), "Must be between 0 and 32000")]
+        [ExpectedException(typeof(ArgumentException))]
         public void Constructor_X0YMinus10_Exception()
         {
             new LabelHomeCommand(0, -10);

--- a/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/QrCodeBarCodeCommandTest.cs
+++ b/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/QrCodeBarCodeCommandTest.cs
@@ -1,0 +1,81 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+
+namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
+{
+    [TestClass]
+    public class QrCodeBarCodeCommandTest
+    {
+        [TestMethod]
+        public void ToZpl_Default1_Successful()
+        {
+            var command = new QrCodeBarCodeCommand(Orientation.Normal, 2, 1, ErrorCorrectionLevel.HighReliability, 7);
+            var zplCommand = command.ToZpl();
+            Assert.AreEqual("^BQN,2,1,Q,7", zplCommand);
+        }
+
+        [TestMethod]
+        public void IsCommandParsable_ValidCommand_True()
+        {
+            var command = new QrCodeBarCodeCommand();
+            var isParsable = command.IsCommandParsable("^BQN,2,1,Q,7");
+            Assert.IsTrue(isParsable);
+        }
+
+        [TestMethod]
+        public void IsCommandParsable_InvalidCommand_False()
+        {
+            var command = new QrCodeBarCodeCommand();
+            var isParsable = command.IsCommandParsable("^FT10,10");
+            Assert.IsFalse(isParsable);
+        }
+
+        [TestMethod]
+        public void ParseCommand_ValidCommand1_Successful()
+        {
+            var command = new QrCodeBarCodeCommand();
+            command.ParseCommand("^BQN");
+            Assert.AreEqual(Orientation.Normal, command.Orientation);
+            Assert.AreEqual(2, command.Model);
+            Assert.AreEqual(1, command.MagnificationFactor);
+            Assert.AreEqual(ErrorCorrectionLevel.HighReliability, command.ErrorCorrection);
+            Assert.AreEqual(7, command.MaskValue);
+        }
+
+        [TestMethod]
+        public void ParseCommand_ValidCommand2_Successful()
+        {
+            var command = new QrCodeBarCodeCommand();
+            command.ParseCommand("^BQN,2,1,Q,7");
+            Assert.AreEqual(Orientation.Normal, command.Orientation);
+            Assert.AreEqual(2, command.Model);
+            Assert.AreEqual(1, command.MagnificationFactor);
+            Assert.AreEqual(ErrorCorrectionLevel.HighReliability, command.ErrorCorrection);
+            Assert.AreEqual(7, command.MaskValue);
+        }
+
+        [TestMethod]
+        public void ParseCommand_ValidCommand3_Successful()
+        {
+            var command = new QrCodeBarCodeCommand();
+            command.ParseCommand("^BQN,1,2,M,1");
+            Assert.AreEqual(Orientation.Normal, command.Orientation);
+            Assert.AreEqual(1, command.Model);
+            Assert.AreEqual(2, command.MagnificationFactor);
+            Assert.AreEqual(ErrorCorrectionLevel.Standard, command.ErrorCorrection);
+            Assert.AreEqual(1, command.MaskValue);
+        }
+
+        [TestMethod]
+        public void ParseCommand_InvalidCommandSetDefaults_Successful()
+        {
+            var command = new QrCodeBarCodeCommand();
+            command.ParseCommand("^BQX,1,2,X,1");
+            Assert.AreEqual(Orientation.Normal, command.Orientation);
+            Assert.AreEqual(1, command.Model);
+            Assert.AreEqual(2, command.MagnificationFactor);
+            Assert.AreEqual(ErrorCorrectionLevel.HighReliability, command.ErrorCorrection);
+            Assert.AreEqual(1, command.MaskValue);
+        }
+    }
+}

--- a/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/RecallGraphicCommandTest.cs
+++ b/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/RecallGraphicCommandTest.cs
@@ -1,0 +1,92 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
+{
+    [TestClass]
+    public class RecallGraphicCommandTest
+    {
+        [TestMethod]
+        public void ToZpl_Default1_Successful()
+        {
+            var command = new RecallGraphicCommand("R:", "TEST.GRF");
+            var zplCommand = command.ToZpl();
+            Assert.AreEqual("^XGR:TEST.GRF,1,1", zplCommand);
+        }
+
+        [TestMethod]
+        public void ToZpl_Default2_Successful()
+        {
+            var command = new RecallGraphicCommand("R:", "TEST.PNG");
+            var zplCommand = command.ToZpl();
+            Assert.AreEqual("^XGR:TEST.PNG,1,1", zplCommand);
+        }
+
+        [TestMethod]
+        public void ToZpl_Default3_Successful()
+        {
+            var command = new RecallGraphicCommand("R:", "TEST.PNG", 2, 2);
+            var zplCommand = command.ToZpl();
+            Assert.AreEqual("^XGR:TEST.PNG,2,2", zplCommand);
+        }
+
+        [TestMethod]
+        public void IsCommandParsable_ValidCommand_True()
+        {
+            var command = new RecallGraphicCommand();
+            var isParsable = command.IsCommandParsable("^XGR:TEST.PNG");
+            Assert.IsTrue(isParsable);
+        }
+
+        [TestMethod]
+        public void IsCommandParsable_InvalidCommand_False()
+        {
+            var command = new RecallGraphicCommand();
+            var isParsable = command.IsCommandParsable("^FT10,10");
+            Assert.IsFalse(isParsable);
+        }
+
+        [TestMethod]
+        public void ParseCommand_ValidCommand1_Successful()
+        {
+            var command = new RecallGraphicCommand();
+            command.ParseCommand("^XGR:TEST.PNG");
+            Assert.AreEqual("R:", command.StorageDevice);
+            Assert.AreEqual("TEST.PNG", command.ImageName);
+            Assert.AreEqual(1, command.MagnificationFactorX);
+            Assert.AreEqual(1, command.MagnificationFactorY);
+        }
+
+        [TestMethod]
+        public void ParseCommand_ValidCommand2_Successful()
+        {
+            var command = new RecallGraphicCommand();
+            command.ParseCommand("^XGR:IMAGE.GRF,2");
+            Assert.AreEqual("R:", command.StorageDevice);
+            Assert.AreEqual("IMAGE.GRF", command.ImageName);
+            Assert.AreEqual(2, command.MagnificationFactorX);
+            Assert.AreEqual(1, command.MagnificationFactorY);
+        }
+
+        [TestMethod]
+        public void ParseCommand_ValidCommand3_Successful()
+        {
+            var command = new RecallGraphicCommand();
+            command.ParseCommand("^XGR:");
+            Assert.AreEqual("R:", command.StorageDevice);
+            Assert.AreEqual("UNKNOWN.GRF", command.ImageName);
+            Assert.AreEqual(1, command.MagnificationFactorX);
+            Assert.AreEqual(1, command.MagnificationFactorY);
+        }
+
+        [TestMethod]
+        public void ParseCommand_ValidCommand4_Successful()
+        {
+            var command = new RecallGraphicCommand();
+            command.ParseCommand("^XGR:IMAGE.GRF,3,3");
+            Assert.AreEqual("R:", command.StorageDevice);
+            Assert.AreEqual("IMAGE.GRF", command.ImageName);
+            Assert.AreEqual(3, command.MagnificationFactorX);
+            Assert.AreEqual(3, command.MagnificationFactorY);
+        }
+    }
+}

--- a/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/ScalableBitmappedFontCommandTest.cs
+++ b/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/ScalableBitmappedFontCommandTest.cs
@@ -33,7 +33,7 @@ namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
         [TestMethod]
         public void ToZpl_Font0Rotated180_Successful()
         {
-            var command = new ScalableBitmappedFontCommand('0', FieldOrientation.Rotated180);
+            var command = new ScalableBitmappedFontCommand('0', Orientation.Rotated180);
             var zplCommand = command.ToZpl();
             Assert.AreEqual("^A0I,10,10", zplCommand);
         }
@@ -42,14 +42,14 @@ namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
         [ExpectedException(typeof(ArgumentException), "Must be between 10 and 32000")]
         public void Constructor_InvalidCharacterHeight_Exception()
         {
-            new ScalableBitmappedFontCommand('A', FieldOrientation.Normal, characterHeight: 0);
+            new ScalableBitmappedFontCommand('A', Orientation.Normal, characterHeight: 0);
         }
 
         [TestMethod]
         [ExpectedException(typeof(ArgumentException), "Must be between 10 and 32000")]
         public void Constructor_InvalidWidth_Exception()
         {
-            new ScalableBitmappedFontCommand('A', FieldOrientation.Normal, width: 0);
+            new ScalableBitmappedFontCommand('A', Orientation.Normal, width: 0);
         }
 
         [TestMethod]
@@ -74,7 +74,7 @@ namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
             var command = new ScalableBitmappedFontCommand();
             command.ParseCommand("^AA");
             Assert.AreEqual(command.FontName, 'A');
-            Assert.AreEqual(command.FieldOrientation, FieldOrientation.Normal);
+            Assert.AreEqual(command.Orientation, Orientation.Normal);
         }
 
         [TestMethod]
@@ -83,7 +83,7 @@ namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
             var command = new ScalableBitmappedFontCommand();
             command.ParseCommand("^A0");
             Assert.AreEqual(command.FontName, '0');
-            Assert.AreEqual(command.FieldOrientation, FieldOrientation.Normal);
+            Assert.AreEqual(command.Orientation, Orientation.Normal);
         }
 
         [TestMethod]
@@ -92,7 +92,7 @@ namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
             var command = new ScalableBitmappedFontCommand();
             command.ParseCommand("^A0N");
             Assert.AreEqual(command.FontName, '0');
-            Assert.AreEqual(command.FieldOrientation, FieldOrientation.Normal);
+            Assert.AreEqual(command.Orientation, Orientation.Normal);
         }
 
         [TestMethod]
@@ -101,7 +101,7 @@ namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
             var command = new ScalableBitmappedFontCommand();
             command.ParseCommand("^A0I");
             Assert.AreEqual(command.FontName, '0');
-            Assert.AreEqual(command.FieldOrientation, FieldOrientation.Rotated180);
+            Assert.AreEqual(command.Orientation, Orientation.Rotated180);
         }
 
         [TestMethod]
@@ -110,7 +110,7 @@ namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
             var command = new ScalableBitmappedFontCommand();
             command.ParseCommand("^A0R");
             Assert.AreEqual(command.FontName, '0');
-            Assert.AreEqual(command.FieldOrientation, FieldOrientation.Rotated90);
+            Assert.AreEqual(command.Orientation, Orientation.Rotated90);
         }
 
         [TestMethod]
@@ -119,7 +119,7 @@ namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
             var command = new ScalableBitmappedFontCommand();
             command.ParseCommand("^A0X");
             Assert.AreEqual(command.FontName, '0');
-            Assert.AreEqual(command.FieldOrientation, FieldOrientation.Normal);
+            Assert.AreEqual(command.Orientation, Orientation.Normal);
             Assert.IsNull(command.CharacterHeight);
             Assert.IsNull(command.Width);
         }
@@ -130,7 +130,7 @@ namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
             var command = new ScalableBitmappedFontCommand();
             command.ParseCommand("^A0B,10");
             Assert.AreEqual(command.FontName, '0');
-            Assert.AreEqual(command.FieldOrientation, FieldOrientation.Rotated270);
+            Assert.AreEqual(command.Orientation, Orientation.Rotated270);
             Assert.AreEqual(command.CharacterHeight, 10);
             Assert.IsNull(command.Width);
         }
@@ -141,7 +141,7 @@ namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
             var command = new ScalableBitmappedFontCommand();
             command.ParseCommand("^A0I,20");
             Assert.AreEqual(command.FontName, '0');
-            Assert.AreEqual(command.FieldOrientation, FieldOrientation.Rotated180);
+            Assert.AreEqual(command.Orientation, Orientation.Rotated180);
             Assert.AreEqual(command.CharacterHeight, 20);
             Assert.IsNull(command.Width);
         }
@@ -152,7 +152,7 @@ namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
             var command = new ScalableBitmappedFontCommand();
             command.ParseCommand("^A0I,,20");
             Assert.AreEqual(command.FontName, '0');
-            Assert.AreEqual(command.FieldOrientation, FieldOrientation.Rotated180);
+            Assert.AreEqual(command.Orientation, Orientation.Rotated180);
             Assert.IsNull(command.CharacterHeight);
             Assert.AreEqual(command.Width, 20);
         }
@@ -163,7 +163,7 @@ namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
             var command = new ScalableBitmappedFontCommand();
             command.ParseCommand("^A0I,100,50");
             Assert.AreEqual(command.FontName, '0');
-            Assert.AreEqual(command.FieldOrientation, FieldOrientation.Rotated180);
+            Assert.AreEqual(command.Orientation, Orientation.Rotated180);
             Assert.AreEqual(command.CharacterHeight, 100);
             Assert.AreEqual(command.Width, 50);
         }

--- a/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/ScalableBitmappedFontCommandTest.cs
+++ b/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/ScalableBitmappedFontCommandTest.cs
@@ -1,0 +1,171 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+
+namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
+{
+    [TestClass]
+    public class ScalableBitmappedFontCommandTest
+    {
+        [TestMethod]
+        public void ToZpl_Font0_Successful()
+        {
+            var command = new ScalableBitmappedFontCommand('0');
+            var zplCommand = command.ToZpl();
+            Assert.AreEqual("^A0N,10,10", zplCommand);
+        }
+
+        [TestMethod]
+        public void ToZpl_Font1_Successful()
+        {
+            var command = new ScalableBitmappedFontCommand('1');
+            var zplCommand = command.ToZpl();
+            Assert.AreEqual("^A1N,10,10", zplCommand);
+        }
+
+        [TestMethod]
+        public void ToZpl_FontA_Successful()
+        {
+            var command = new ScalableBitmappedFontCommand('A');
+            var zplCommand = command.ToZpl();
+            Assert.AreEqual("^AAN,10,10", zplCommand);
+        }
+
+        [TestMethod]
+        public void ToZpl_Font0Rotated180_Successful()
+        {
+            var command = new ScalableBitmappedFontCommand('0', FieldOrientation.Rotated180);
+            var zplCommand = command.ToZpl();
+            Assert.AreEqual("^A0I,10,10", zplCommand);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException), "Must be between 10 and 32000")]
+        public void Constructor_InvalidCharacterHeight_Exception()
+        {
+            new ScalableBitmappedFontCommand('A', FieldOrientation.Normal, characterHeight: 0);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException), "Must be between 10 and 32000")]
+        public void Constructor_InvalidWidth_Exception()
+        {
+            new ScalableBitmappedFontCommand('A', FieldOrientation.Normal, width: 0);
+        }
+
+        [TestMethod]
+        public void IsCommandParsable_ValidCommand_True()
+        {
+            var command = new ScalableBitmappedFontCommand();
+            var isParsable = command.IsCommandParsable("^AAN10,10");
+            Assert.IsTrue(isParsable);
+        }
+
+        [TestMethod]
+        public void IsCommandParsable_InvalidCommand_False()
+        {
+            var command = new ScalableBitmappedFontCommand();
+            var isParsable = command.IsCommandParsable("^FT10,10");
+            Assert.IsFalse(isParsable);
+        }
+
+        [TestMethod]
+        public void ParseCommand_ValidCommand1_Successful()
+        {
+            var command = new ScalableBitmappedFontCommand();
+            command.ParseCommand("^AA");
+            Assert.AreEqual(command.FontName, 'A');
+            Assert.AreEqual(command.FieldOrientation, FieldOrientation.Normal);
+        }
+
+        [TestMethod]
+        public void ParseCommand_ValidCommand2_Successful()
+        {
+            var command = new ScalableBitmappedFontCommand();
+            command.ParseCommand("^A0");
+            Assert.AreEqual(command.FontName, '0');
+            Assert.AreEqual(command.FieldOrientation, FieldOrientation.Normal);
+        }
+
+        [TestMethod]
+        public void ParseCommand_ValidCommand3_Successful()
+        {
+            var command = new ScalableBitmappedFontCommand();
+            command.ParseCommand("^A0N");
+            Assert.AreEqual(command.FontName, '0');
+            Assert.AreEqual(command.FieldOrientation, FieldOrientation.Normal);
+        }
+
+        [TestMethod]
+        public void ParseCommand_ValidCommand4_Successful()
+        {
+            var command = new ScalableBitmappedFontCommand();
+            command.ParseCommand("^A0I");
+            Assert.AreEqual(command.FontName, '0');
+            Assert.AreEqual(command.FieldOrientation, FieldOrientation.Rotated180);
+        }
+
+        [TestMethod]
+        public void ParseCommand_ValidCommand5_Successful()
+        {
+            var command = new ScalableBitmappedFontCommand();
+            command.ParseCommand("^A0R");
+            Assert.AreEqual(command.FontName, '0');
+            Assert.AreEqual(command.FieldOrientation, FieldOrientation.Rotated90);
+        }
+
+        [TestMethod]
+        public void ParseCommand_InvalidFieldOrientationCommand_Successful()
+        {
+            var command = new ScalableBitmappedFontCommand();
+            command.ParseCommand("^A0X");
+            Assert.AreEqual(command.FontName, '0');
+            Assert.AreEqual(command.FieldOrientation, FieldOrientation.Normal);
+            Assert.IsNull(command.CharacterHeight);
+            Assert.IsNull(command.Width);
+        }
+
+        [TestMethod]
+        public void ParseCommand_ValidCommand6_Successful()
+        {
+            var command = new ScalableBitmappedFontCommand();
+            command.ParseCommand("^A0B,10");
+            Assert.AreEqual(command.FontName, '0');
+            Assert.AreEqual(command.FieldOrientation, FieldOrientation.Rotated270);
+            Assert.AreEqual(command.CharacterHeight, 10);
+            Assert.IsNull(command.Width);
+        }
+
+        [TestMethod]
+        public void ParseCommand_ValidCommand7_Successful()
+        {
+            var command = new ScalableBitmappedFontCommand();
+            command.ParseCommand("^A0I,20");
+            Assert.AreEqual(command.FontName, '0');
+            Assert.AreEqual(command.FieldOrientation, FieldOrientation.Rotated180);
+            Assert.AreEqual(command.CharacterHeight, 20);
+            Assert.IsNull(command.Width);
+        }
+
+        [TestMethod]
+        public void ParseCommand_ValidCommand8_Successful()
+        {
+            var command = new ScalableBitmappedFontCommand();
+            command.ParseCommand("^A0I,,20");
+            Assert.AreEqual(command.FontName, '0');
+            Assert.AreEqual(command.FieldOrientation, FieldOrientation.Rotated180);
+            Assert.IsNull(command.CharacterHeight);
+            Assert.AreEqual(command.Width, 20);
+        }
+
+        [TestMethod]
+        public void ParseCommand_ValidCommand9_Successful()
+        {
+            var command = new ScalableBitmappedFontCommand();
+            command.ParseCommand("^A0I,100,50");
+            Assert.AreEqual(command.FontName, '0');
+            Assert.AreEqual(command.FieldOrientation, FieldOrientation.Rotated180);
+            Assert.AreEqual(command.CharacterHeight, 100);
+            Assert.AreEqual(command.Width, 50);
+        }
+    }
+}

--- a/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/ScalableBitmappedFontCommandTest.cs
+++ b/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/ScalableBitmappedFontCommandTest.cs
@@ -73,8 +73,8 @@ namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
         {
             var command = new ScalableBitmappedFontCommand();
             command.ParseCommand("^AA");
-            Assert.AreEqual(command.FontName, 'A');
-            Assert.AreEqual(command.Orientation, Orientation.Normal);
+            Assert.AreEqual('A', command.FontName);
+            Assert.AreEqual(Orientation.Normal, command.Orientation);
         }
 
         [TestMethod]
@@ -82,8 +82,8 @@ namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
         {
             var command = new ScalableBitmappedFontCommand();
             command.ParseCommand("^A0");
-            Assert.AreEqual(command.FontName, '0');
-            Assert.AreEqual(command.Orientation, Orientation.Normal);
+            Assert.AreEqual('0', command.FontName);
+            Assert.AreEqual(Orientation.Normal, command.Orientation);
         }
 
         [TestMethod]
@@ -91,8 +91,8 @@ namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
         {
             var command = new ScalableBitmappedFontCommand();
             command.ParseCommand("^A0N");
-            Assert.AreEqual(command.FontName, '0');
-            Assert.AreEqual(command.Orientation, Orientation.Normal);
+            Assert.AreEqual('0', command.FontName);
+            Assert.AreEqual(Orientation.Normal, command.Orientation);
         }
 
         [TestMethod]
@@ -100,8 +100,8 @@ namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
         {
             var command = new ScalableBitmappedFontCommand();
             command.ParseCommand("^A0I");
-            Assert.AreEqual(command.FontName, '0');
-            Assert.AreEqual(command.Orientation, Orientation.Rotated180);
+            Assert.AreEqual('0', command.FontName);
+            Assert.AreEqual(Orientation.Rotated180, command.Orientation);
         }
 
         [TestMethod]
@@ -109,8 +109,8 @@ namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
         {
             var command = new ScalableBitmappedFontCommand();
             command.ParseCommand("^A0R");
-            Assert.AreEqual(command.FontName, '0');
-            Assert.AreEqual(command.Orientation, Orientation.Rotated90);
+            Assert.AreEqual('0', command.FontName);
+            Assert.AreEqual(Orientation.Rotated90, command.Orientation);
         }
 
         [TestMethod]
@@ -118,8 +118,8 @@ namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
         {
             var command = new ScalableBitmappedFontCommand();
             command.ParseCommand("^A0X");
-            Assert.AreEqual(command.FontName, '0');
-            Assert.AreEqual(command.Orientation, Orientation.Normal);
+            Assert.AreEqual('0', command.FontName);
+            Assert.AreEqual(Orientation.Normal, command.Orientation);
             Assert.IsNull(command.CharacterHeight);
             Assert.IsNull(command.Width);
         }
@@ -129,9 +129,9 @@ namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
         {
             var command = new ScalableBitmappedFontCommand();
             command.ParseCommand("^A0B,10");
-            Assert.AreEqual(command.FontName, '0');
-            Assert.AreEqual(command.Orientation, Orientation.Rotated270);
-            Assert.AreEqual(command.CharacterHeight, 10);
+            Assert.AreEqual('0', command.FontName);
+            Assert.AreEqual(Orientation.Rotated270, command.Orientation);
+            Assert.AreEqual(10, command.CharacterHeight);
             Assert.IsNull(command.Width);
         }
 
@@ -140,9 +140,9 @@ namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
         {
             var command = new ScalableBitmappedFontCommand();
             command.ParseCommand("^A0I,20");
-            Assert.AreEqual(command.FontName, '0');
-            Assert.AreEqual(command.Orientation, Orientation.Rotated180);
-            Assert.AreEqual(command.CharacterHeight, 20);
+            Assert.AreEqual('0', command.FontName);
+            Assert.AreEqual(Orientation.Rotated180, command.Orientation);
+            Assert.AreEqual(20, command.CharacterHeight);
             Assert.IsNull(command.Width);
         }
 
@@ -151,10 +151,10 @@ namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
         {
             var command = new ScalableBitmappedFontCommand();
             command.ParseCommand("^A0I,,20");
-            Assert.AreEqual(command.FontName, '0');
-            Assert.AreEqual(command.Orientation, Orientation.Rotated180);
+            Assert.AreEqual('0', command.FontName);
+            Assert.AreEqual(Orientation.Rotated180, command.Orientation);
             Assert.IsNull(command.CharacterHeight);
-            Assert.AreEqual(command.Width, 20);
+            Assert.AreEqual(20, command.Width);
         }
 
         [TestMethod]
@@ -162,10 +162,10 @@ namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
         {
             var command = new ScalableBitmappedFontCommand();
             command.ParseCommand("^A0I,100,50");
-            Assert.AreEqual(command.FontName, '0');
-            Assert.AreEqual(command.Orientation, Orientation.Rotated180);
-            Assert.AreEqual(command.CharacterHeight, 100);
-            Assert.AreEqual(command.Width, 50);
+            Assert.AreEqual('0', command.FontName);
+            Assert.AreEqual(Orientation.Rotated180, command.Orientation);
+            Assert.AreEqual(100, command.CharacterHeight);
+            Assert.AreEqual(50, command.Width);
         }
     }
 }

--- a/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/ScalableBitmappedFontCommandTest.cs
+++ b/src/BinaryKits.Zpl.Protocol.UnitTest/Commands/ScalableBitmappedFontCommandTest.cs
@@ -39,14 +39,14 @@ namespace BinaryKits.Zpl.Protocol.Commands.UnitTest
         }
 
         [TestMethod]
-        [ExpectedException(typeof(ArgumentException), "Must be between 10 and 32000")]
+        [ExpectedException(typeof(ArgumentException))]
         public void Constructor_InvalidCharacterHeight_Exception()
         {
             new ScalableBitmappedFontCommand('A', Orientation.Normal, characterHeight: 0);
         }
 
         [TestMethod]
-        [ExpectedException(typeof(ArgumentException), "Must be between 10 and 32000")]
+        [ExpectedException(typeof(ArgumentException))]
         public void Constructor_InvalidWidth_Exception()
         {
             new ScalableBitmappedFontCommand('A', Orientation.Normal, width: 0);

--- a/src/BinaryKits.Zpl.Protocol.UnitTest/ZebraHexCompressionHelperTest.cs
+++ b/src/BinaryKits.Zpl.Protocol.UnitTest/ZebraHexCompressionHelperTest.cs
@@ -1,0 +1,141 @@
+﻿using BinaryKits.Zpl.Protocol.Helpers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace BinaryKits.Zpl.Protocol.UnitTest
+{
+    [TestClass]
+    public class ZebraHexCompressionHelperTest
+    {
+        [TestMethod]
+        [DataRow(1, "G")]
+        [DataRow(2, "H")]
+        [DataRow(3, "I")]
+        [DataRow(4, "J")]
+        [DataRow(5, "K")]
+        [DataRow(6, "L")]
+        [DataRow(7, "M")]
+        [DataRow(8, "N")]
+        [DataRow(9, "O")]
+        [DataRow(10, "P")]
+        [DataRow(11, "Q")]
+        [DataRow(12, "R")]
+        [DataRow(13, "S")]
+        [DataRow(14, "T")]
+        [DataRow(15, "U")]
+        [DataRow(16, "V")]
+        [DataRow(17, "W")]
+        [DataRow(18, "X")]
+        [DataRow(19, "Y")]
+        [DataRow(20, "g")]
+        [DataRow(40, "h")]
+        [DataRow(60, "i")]
+        [DataRow(80, "j")]
+        [DataRow(100, "k")]
+        [DataRow(120, "l")]
+        [DataRow(140, "m")]
+        [DataRow(160, "n")]
+        [DataRow(180, "o")]
+        [DataRow(200, "p")]
+        [DataRow(220, "q")]
+        [DataRow(240, "r")]
+        [DataRow(260, "s")]
+        [DataRow(280, "t")]
+        [DataRow(300, "u")]
+        [DataRow(320, "v")]
+        [DataRow(340, "w")]
+        [DataRow(360, "x")]
+        [DataRow(380, "y")]
+        [DataRow(400, "z")]
+        public void GetZebraCharCount_Simple_Successful(int charRepeatCount, string compressed)
+        {
+            var zebraCharCount = ZebraHexCompressionHelper.GetZebraCharCount(charRepeatCount);
+            Assert.AreEqual(compressed, zebraCharCount);
+        }
+
+        [TestMethod]
+        [DataRow(21, "gG")]
+        [DataRow(22, "gH")]
+        [DataRow(23, "gI")]
+        [DataRow(24, "gJ")]
+        [DataRow(25, "gK")]
+        [DataRow(30, "gP")]
+        [DataRow(35, "gU")]
+        [DataRow(36, "gV")]
+        [DataRow(37, "gW")]
+        [DataRow(38, "gX")]
+        [DataRow(39, "gY")]
+        [DataRow(50, "hP")]
+        [DataRow(642, "zrH")]
+        [DataRow(800, "zz")]
+        [DataRow(842, "zzhH")]
+        public void GetZebraCharCount_Complex_Successful(int charRepeatCount, string compressed)
+        {
+            var zebraCharCount = ZebraHexCompressionHelper.GetZebraCharCount(charRepeatCount);
+            Assert.AreEqual(compressed, zebraCharCount);
+        }
+
+        [TestMethod]
+        public void Compress_ValidData1_Successful()
+        {
+            var compressed = ZebraHexCompressionHelper.Compress("FFFF\nF00F\nFFFF\n", 2);
+            Assert.AreEqual("JFGFH0GFJF", compressed);
+            //^XA
+            //~DGR:SAMPLE.GRF,00006,02,JFGFH0GFJF
+            //^FO20,20
+            //^XGR:SAMPLE.GRF,1,1^FS
+            //^XZ
+        }
+
+        [TestMethod]
+        public void Compress_ValidData2_Successful()
+        {
+            var compressed = ZebraHexCompressionHelper.Compress("FFFFF00FFFFF", 2);
+            Assert.AreEqual("JFGFH0GFJF", compressed);
+            //^XA
+            //~DGR:SAMPLE.GRF,00006,02,JFGFH0GFJF
+            //^FO20,20
+            //^XGR:SAMPLE.GRF,1,1^FS
+            //^XZ
+        }
+
+        [TestMethod]
+        public void Compress_ValidData3_Successful()
+        {
+            var compressed = ZebraHexCompressionHelper.Compress("FFFFFFFFFFFFFFFFFFFF\n8000FFFF0000FFFF0001\n8000FFFF0000FFFF0001\n8000FFFF0000FFFF0001\nFFFF0000FFFF0000FFFF\nFFFF0000FFFF0000FFFF\nFFFF0000FFFF0000FFFF\nFFFFFFFFFFFFFFFFFFFF\n", 10);
+            Assert.AreEqual("gFG8I0JFJ0JFI0!::JFJ0JFJ0JF::gF", compressed);
+            //^XA
+            //~DGR:SAMPLE.GRF,00080,010,gFG8I0JFJ0JFI0!::JFJ0JFJ0JF::gF
+            //^FO20,20
+            //^XGR:SAMPLE.GRF,1,1 ^ FS
+            //^XZ
+        }
+
+        [TestMethod]
+        public void CompressUncompress_Flow_Successful()
+        {
+            var originalData = "FFFFFFFFFFFFFFFFFFFF\n8000FFFF0000FFFF0001\n8000FFFF0000FFFF0001\n8000FFFF0000FFFF0001\nFFFF0000FFFF0000FFFF\nFFFF0000FFFF0000FFFF\nFFFF0000FFFF0000FFFF\nFFFFFFFFFFFFFFFFFFFF\n";
+
+            var compressed = ZebraHexCompressionHelper.Compress(originalData, 10);
+            var uncompressed = ZebraHexCompressionHelper.Uncompress(compressed, 10);
+            Assert.AreEqual(originalData, uncompressed);
+        }
+
+        [TestMethod]
+        public void Uncompress_ValidData1_Successful()
+        {
+            var compressedData = "gO0E\n";
+
+            var uncompressed = ZebraHexCompressionHelper.Uncompress(compressedData, 10);
+            Assert.AreEqual("00000000000000000000000000000E\n", uncompressed);
+        }
+
+        [TestMethod]
+        public void Uncompress_ValidData2_Successful()
+        {
+            var compressedData = "gO0GE\n";
+
+            var uncompressed = ZebraHexCompressionHelper.Uncompress(compressedData, 10);
+            Assert.AreEqual("00000000000000000000000000000E\n", uncompressed);
+        }
+    }
+}

--- a/src/BinaryKits.Zpl.Protocol/BinaryKits.Zpl.Protocol.csproj
+++ b/src/BinaryKits.Zpl.Protocol/BinaryKits.Zpl.Protocol.csproj
@@ -2,12 +2,12 @@
 
   <PropertyGroup>
     <TargetFrameworks>net472;netstandard2.0;net5.0</TargetFrameworks>
-    <Description>This package contains the basic commands of the Zebra Programming Language. It also supports you with image conversion.</Description>
+    <Description>This package contains the zebra protocol of the Zebra Programming Language. It also supports you with image conversion.</Description>
     <Company>Binary Kits Pte. Ltd.</Company>
-    <Version>3.0.2</Version>
+    <Version>1.0.0</Version>
     <Authors>Binary Kits Pte. Ltd.</Authors>
     <PackageReleaseNotes></PackageReleaseNotes>
-    <PackageTags>Zebra ZPL ZPL2 Printer Label</PackageTags>
+    <PackageTags>Zebra ZPL ZPL2 Printer Protocol</PackageTags>
     <PackageProjectUrl>https://github.com/BinaryKits/BinaryKits.Zpl</PackageProjectUrl>
     <RepositoryUrl>https://github.com/BinaryKits/BinaryKits.Zpl</RepositoryUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/BinaryKits.Zpl.Protocol/BinaryKits.Zpl.Protocol.csproj
+++ b/src/BinaryKits.Zpl.Protocol/BinaryKits.Zpl.Protocol.csproj
@@ -1,0 +1,42 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net472;netstandard2.0;net5.0</TargetFrameworks>
+    <Description>This package contains the basic commands of the Zebra Programming Language. It also supports you with image conversion.</Description>
+    <Company>Binary Kits Pte. Ltd.</Company>
+    <Version>3.0.2</Version>
+    <Authors>Binary Kits Pte. Ltd.</Authors>
+    <PackageReleaseNotes></PackageReleaseNotes>
+    <PackageTags>Zebra ZPL ZPL2 Printer Label</PackageTags>
+    <PackageProjectUrl>https://github.com/BinaryKits/BinaryKits.Zpl</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/BinaryKits/BinaryKits.Zpl</RepositoryUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageId>BinaryKits.Zpl.Protocol</PackageId>
+    <PackageIcon>logo_128.png</PackageIcon>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <AssemblyName>BinaryKits.Zpl.Protocol</AssemblyName>
+    <RootNamespace>BinaryKits.Zpl.Protocol</RootNamespace>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="SixLabors.ImageSharp">
+      <Version>1.0.3</Version>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\LICENSE" Pack="true" PackagePath="LICENSE" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\doc\logo_128.png">
+      <Pack>true</Pack>
+      <Visible>false</Visible>
+      <PackagePath></PackagePath>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/src/BinaryKits.Zpl.Protocol/Commands/BarCodeFieldDefaultCommand.cs
+++ b/src/BinaryKits.Zpl.Protocol/Commands/BarCodeFieldDefaultCommand.cs
@@ -1,0 +1,91 @@
+﻿using System.Globalization;
+using static System.FormattableString;
+
+namespace BinaryKits.Zpl.Protocol.Commands
+{
+    /// <summary>
+    /// Bar Code Field Default
+    /// The ^BY command is used to change the default values for the module width (in dots), the wide bar to narrow 
+    /// bar width ratio and the bar code height(in dots). It can be used as often as necessary within a label format.
+    /// </summary>
+    public class BarCodeFieldDefaultCommand : CommandBase
+    {
+        /// <summary>
+        /// Module width
+        /// </summary>
+        public int ModuleWidth { get; private set; } = 2;
+
+        /// <summary>
+        /// Wide bar to narrow bar width ratio
+        /// </summary>
+        public double WideBarToNarrowBarWidthRatio { get; private set; } = 3.0;
+
+        /// <summary>
+        /// Bar code height
+        /// </summary>
+        public int BarCodeHeight { get; private set; } = 10;
+
+        /// <summary>
+        /// Bar Code Field Default
+        /// </summary>
+        public BarCodeFieldDefaultCommand() : base("^BY")
+        { }
+
+        /// <summary>
+        /// Bar Code Field Default
+        /// </summary>
+        /// <param name="moduleWidth">Module width (1 to 10)</param>
+        /// <param name="wideBarToNarrowBarWidthRatio">Wide bar to narrow bar width ratio (2.0 to 3.0, in 0.1 increments)</param>
+        /// <param name="barCodeHeight">Bar code height</param>
+        public BarCodeFieldDefaultCommand(
+            int moduleWidth,
+            double wideBarToNarrowBarWidthRatio,
+            int barCodeHeight)
+            : this()
+        {
+            if (this.ValidateIntParameter(nameof(moduleWidth), moduleWidth, 1, 10))
+            {
+                this.ModuleWidth = moduleWidth;
+            }
+
+            this.WideBarToNarrowBarWidthRatio = wideBarToNarrowBarWidthRatio;
+            this.BarCodeHeight = barCodeHeight;
+        }
+
+        ///<inheritdoc/>
+        public override string ToZpl()
+        {
+            return Invariant($"{this.CommandPrefix}{this.ModuleWidth},{this.WideBarToNarrowBarWidthRatio:0.0},{this.BarCodeHeight}");
+        }
+
+        ///<inheritdoc/>
+        public override void ParseCommand(string zplCommand)
+        {
+            var zplDataParts = this.SplitCommand(zplCommand);
+
+            if (zplDataParts.Length > 0)
+            {
+                if (int.TryParse(zplDataParts[0], out var moduleWidth))
+                {
+                    this.ModuleWidth = moduleWidth;
+                }
+            }
+
+            if (zplDataParts.Length > 1)
+            {
+                if (double.TryParse(zplDataParts[1], NumberStyles.Any, CultureInfo.InvariantCulture, out var wideBarToNarrowBarWidthRatio))
+                {
+                    this.WideBarToNarrowBarWidthRatio = wideBarToNarrowBarWidthRatio;
+                }
+            }
+
+            if (zplDataParts.Length > 2)
+            {
+                if (int.TryParse(zplDataParts[2], out var barCodeHeight))
+                {
+                    this.BarCodeHeight = barCodeHeight;
+                }
+            }
+        }
+    }
+}

--- a/src/BinaryKits.Zpl.Protocol/Commands/ChangeAlphanumericDefaultFontCommand.cs
+++ b/src/BinaryKits.Zpl.Protocol/Commands/ChangeAlphanumericDefaultFontCommand.cs
@@ -1,0 +1,89 @@
+﻿namespace BinaryKits.Zpl.Protocol.Commands
+{
+    /// <summary>
+    /// Change Alphanumeric Default Font<br/>
+    /// The ^CF command sets the default font used in your printer. You can use the ^CF command to simplify your
+    /// programs.
+    /// </summary>
+    public class ChangeAlphanumericDefaultFontCommand : CommandBase
+    {
+        /// <summary>
+        /// Specified default font
+        /// </summary>
+        public char SpecifiedDefaultFont { get; private set; }
+
+        /// <summary>
+        /// Individual character height
+        /// </summary>
+        public int? IndividualCharacterHeight { get; private set; }
+
+        /// <summary>
+        /// Individual character width
+        /// </summary>
+        public int? IndividualCharacterWidth { get; private set; }
+
+        /// <summary>
+        /// Change Alphanumeric Default Font
+        /// </summary>
+        public ChangeAlphanumericDefaultFontCommand() : base("^CF")
+        { }
+
+        /// <summary>
+        /// Change Alphanumeric Default Font
+        /// </summary>
+        /// <param name="specifiedDefaultFont">Specified default font</param>
+        /// <param name="individualCharacterHeight">Individual character height (0 to 32000)</param>
+        /// <param name="individualCharacterWidth">Individual character width (0 to 32000)</param>
+        public ChangeAlphanumericDefaultFontCommand(
+            char specifiedDefaultFont,
+            int? individualCharacterHeight = null,
+            int? individualCharacterWidth = null)
+            : this()
+        {
+            this.SpecifiedDefaultFont = specifiedDefaultFont;
+
+            if (this.ValidateIntParameter(nameof(individualCharacterHeight), individualCharacterHeight, 0, 32000))
+            {
+                this.IndividualCharacterHeight = individualCharacterHeight.Value;
+            }
+
+            if (this.ValidateIntParameter(nameof(individualCharacterWidth), individualCharacterWidth, 0, 32000))
+            {
+                this.IndividualCharacterWidth = individualCharacterWidth.Value;
+            }
+        }
+
+        ///<inheritdoc/>
+        public override string ToZpl()
+        {
+            return $"{this.CommandPrefix}{this.SpecifiedDefaultFont},{this.IndividualCharacterHeight},{this.IndividualCharacterWidth}";
+        }
+
+        ///<inheritdoc/>
+        public override void ParseCommand(string zplCommand)
+        {
+            var zplDataParts = this.SplitCommand(zplCommand);
+
+            if (zplDataParts.Length > 0)
+            {
+                this.SpecifiedDefaultFont = zplDataParts[0][0];
+            }
+
+            if (zplDataParts.Length > 1)
+            {
+                if (int.TryParse(zplDataParts[1], out var individualCharacterHeight))
+                {
+                    this.IndividualCharacterHeight = individualCharacterHeight;
+                }
+            }
+
+            if (zplDataParts.Length > 2)
+            {
+                if (int.TryParse(zplDataParts[2], out var individualCharacterWidth))
+                {
+                    this.IndividualCharacterWidth = individualCharacterWidth;
+                }
+            }
+        }
+    }
+}

--- a/src/BinaryKits.Zpl.Protocol/Commands/Code128BarCodeCommand.cs
+++ b/src/BinaryKits.Zpl.Protocol/Commands/Code128BarCodeCommand.cs
@@ -1,0 +1,112 @@
+﻿namespace BinaryKits.Zpl.Protocol.Commands
+{
+    /// <summary>
+    /// Code 128 Bar Code (Subsets A, B, and C)<br/>
+    /// The ^BC command creates the Code 128 bar code, a high-density, variable length, continuous,
+    /// alphanumeric symbology.It was designed for complexly encoded product identification.
+    /// Code 128 has three subsets of characters.There are 106 encoded printing characters in each set, and
+    /// each character can have up to three different meanings, depending on the character subset being used.
+    /// Each Code 128 character consists of six elements: three bars and three spaces.
+    /// </summary>
+    public class Code128BarCodeCommand : CommandBase
+    {
+        /// <summary>
+        /// Orientation
+        /// </summary>
+        public Orientation Orientation { get; private set; } = Orientation.Normal;
+
+        /// <summary>
+        /// Bar code height
+        /// </summary>
+        public int? BarCodeHeight { get; private set; }
+
+        /// <summary>
+        /// Print interpretation line
+        /// </summary>
+        public bool PrintInterpretationLine { get; private set; } = true;
+
+        /// <summary>
+        /// Print interpretation line above code
+        /// </summary>
+        public bool PrintInterpretationLineAboveCode { get; private set; } = false;
+
+        /// <summary>
+        /// UCC check digit
+        /// </summary>
+        public bool UccCheckDigit { get; private set; } = false;
+
+        /// <summary>
+        /// Code 128 Bar Code (Subsets A, B, and C)
+        /// </summary>
+        public Code128BarCodeCommand() : base("^BC")
+        { }
+
+        /// <summary>
+        /// Code 128 Bar Code (Subsets A, B, and C)
+        /// </summary>
+        /// <param name="orientation">Orientation</param>
+        /// <param name="barCodeHeight">Bar code height (1 to 32000)</param>
+        /// <param name="printInterpretationLine">Print interpretation line</param>
+        /// <param name="printInterpretationLineAboveCode">Print interpretation line above code</param>
+        /// <param name="uccCheckDigit">UCC check digit</param>
+        public Code128BarCodeCommand(
+            Orientation orientation = Orientation.Normal,
+            int? barCodeHeight = null,
+            bool printInterpretationLine = true,
+            bool printInterpretationLineAboveCode = false,
+            bool uccCheckDigit = false)
+            : this()
+        {
+            this.Orientation = orientation;
+
+            if (this.ValidateIntParameter(nameof(barCodeHeight), barCodeHeight, 1, 32000))
+            {
+                this.BarCodeHeight = barCodeHeight.Value;
+            }
+
+            this.PrintInterpretationLine = printInterpretationLine;
+            this.PrintInterpretationLineAboveCode = printInterpretationLineAboveCode;
+            this.UccCheckDigit = uccCheckDigit;
+        }
+
+        ///<inheritdoc/>
+        public override string ToZpl()
+        {
+            return $"{this.CommandPrefix}{this.RenderOrientation(this.Orientation)},{this.BarCodeHeight},{this.RenderBoolean(this.PrintInterpretationLine)},{this.RenderBoolean(this.PrintInterpretationLineAboveCode)},{this.RenderBoolean(this.UccCheckDigit)}";
+        }
+
+        ///<inheritdoc/>
+        public override void ParseCommand(string zplCommand)
+        {
+            var zplDataParts = this.SplitCommand(zplCommand);
+
+            if (zplDataParts.Length > 0)
+            {
+                this.Orientation = this.ConvertOrientation(zplDataParts[0]);
+            }
+
+            if (zplDataParts.Length > 1)
+            {
+                if (int.TryParse(zplDataParts[1], out var barCodeHeight))
+                {
+                    this.BarCodeHeight = barCodeHeight;
+                }
+            }
+
+            if (zplDataParts.Length > 2)
+            {
+                this.PrintInterpretationLine = this.ConvertBoolean(zplDataParts[2]);
+            }
+
+            if (zplDataParts.Length > 3)
+            {
+                this.PrintInterpretationLineAboveCode = this.ConvertBoolean(zplDataParts[3]);
+            }
+
+            if (zplDataParts.Length > 4)
+            {
+                this.UccCheckDigit = this.ConvertBoolean(zplDataParts[4]);
+            }
+        }
+    }
+}

--- a/src/BinaryKits.Zpl.Protocol/Commands/Code39BarCodeCommand.cs
+++ b/src/BinaryKits.Zpl.Protocol/Commands/Code39BarCodeCommand.cs
@@ -1,0 +1,112 @@
+﻿namespace BinaryKits.Zpl.Protocol.Commands
+{
+    /// <summary>
+    /// Code 39 Bar Code<br/>
+    /// The Code 39 bar code is the standard for many industries, including the U.S. Department of Defense. It is
+    /// one of three symbologies identified in the American National Standards Institute(ANSI) standard
+    /// MH10.8M-1983. Code 39 is also known as USD-3 Code and 3 of 9 Code.
+    /// </summary>
+    public class Code39BarCodeCommand : CommandBase
+    {
+        /// <summary>
+        /// Orientation
+        /// </summary>
+        public Orientation Orientation { get; private set; } = Orientation.Normal;
+
+        /// <summary>
+        /// Mod-43 check digit
+        /// </summary>
+        public bool Mod43CheckDigit { get; private set; } = false;
+
+        /// <summary>
+        /// Bar code height
+        /// </summary>
+        public int? BarCodeHeight { get; private set; }
+
+        /// <summary>
+        /// Print interpretation line
+        /// </summary>
+        public bool PrintInterpretationLine { get; private set; } = true;
+
+        /// <summary>
+        /// Print interpretation line above code
+        /// </summary>
+        public bool PrintInterpretationLineAboveCode { get; private set; } = false;
+
+        /// <summary>
+        /// Code 39 Bar Code
+        /// </summary>
+        public Code39BarCodeCommand() : base("^B3")
+        { }
+
+        /// <summary>
+        /// Code 39 Bar Code
+        /// </summary>
+        /// <param name="orientation">Orientation</param>
+        /// <param name="mod43CheckDigit">Mod-43 check digit</param>
+        /// <param name="barCodeHeight">Bar code height (1 to 32000)</param>
+        /// <param name="printInterpretationLine">Print interpretation line</param>
+        /// <param name="printInterpretationLineAboveCode">Print interpretation line above code</param>
+        public Code39BarCodeCommand(
+            Orientation orientation = Orientation.Normal,
+            bool mod43CheckDigit = false,
+            int? barCodeHeight = null,
+            bool printInterpretationLine = true,
+            bool printInterpretationLineAboveCode = false
+            )
+            : this()
+        {
+            this.Orientation = orientation;
+
+            this.Mod43CheckDigit = mod43CheckDigit;
+
+            if (this.ValidateIntParameter(nameof(barCodeHeight), barCodeHeight, 1, 32000))
+            {
+                this.BarCodeHeight = barCodeHeight.Value;
+            }
+
+            this.PrintInterpretationLine = printInterpretationLine;
+            this.PrintInterpretationLineAboveCode = printInterpretationLineAboveCode;
+        }
+
+        ///<inheritdoc/>
+        public override string ToZpl()
+        {
+            return $"{this.CommandPrefix}{this.RenderOrientation(this.Orientation)},{this.RenderBoolean(this.Mod43CheckDigit)},{this.BarCodeHeight},{this.RenderBoolean(this.PrintInterpretationLine)},{this.RenderBoolean(this.PrintInterpretationLineAboveCode)}";
+        }
+
+        ///<inheritdoc/>
+        public override void ParseCommand(string zplCommand)
+        {
+            var zplDataParts = this.SplitCommand(zplCommand);
+
+            if (zplDataParts.Length > 0)
+            {
+                this.Orientation = this.ConvertOrientation(zplDataParts[0]);
+            }
+
+            if (zplDataParts.Length > 1)
+            {
+                this.Mod43CheckDigit = this.ConvertBoolean(zplDataParts[1]);
+            }
+
+            if (zplDataParts.Length > 2)
+            {
+                if (int.TryParse(zplDataParts[2], out var barCodeHeight))
+                {
+                    this.BarCodeHeight = barCodeHeight;
+                }
+            }
+
+            if (zplDataParts.Length > 3)
+            {
+                this.PrintInterpretationLine = this.ConvertBoolean(zplDataParts[3]);
+            }
+
+            if (zplDataParts.Length > 4)
+            {
+                this.PrintInterpretationLineAboveCode = this.ConvertBoolean(zplDataParts[4]);
+            }
+        }
+    }
+}

--- a/src/BinaryKits.Zpl.Protocol/Commands/CommandBase.cs
+++ b/src/BinaryKits.Zpl.Protocol/Commands/CommandBase.cs
@@ -1,0 +1,58 @@
+﻿using System;
+
+namespace BinaryKits.Zpl.Protocol.Commands
+{
+    /// <summary>
+    /// Command Base
+    /// </summary>
+    public abstract class CommandBase
+    {
+        /// <summary>
+        /// The Command Prefix
+        /// </summary>
+        protected string CommandPrefix { get; private set; }
+
+        /// <summary>
+        /// Command Base
+        /// </summary>
+        /// <param name="commandPrefix"></param>
+        public CommandBase(string commandPrefix)
+        {
+            this.CommandPrefix = commandPrefix;
+        }
+
+        /// <summary>
+        /// Split a zpl command in data parts
+        /// </summary>
+        /// <param name="zplCommand"></param>
+        /// <param name="dataStartIndex"></param>
+        /// <returns></returns>
+        protected string[] SplitCommand(string zplCommand, int dataStartIndex = 0)
+        {
+            var zplCommandData = zplCommand.Substring(this.CommandPrefix.Length + dataStartIndex);
+            return zplCommandData.Split(',');
+        }
+
+        /// <summary>
+        /// Get the Zpl Command
+        /// </summary>
+        /// <returns></returns>
+        public abstract string ToZpl();
+
+        /// <summary>
+        /// Check the zpl command is parsable
+        /// </summary>
+        /// <param name="zplCommand"></param>
+        /// <returns></returns>
+        public bool IsCommandParsable(string zplCommand)
+        {
+            return zplCommand.StartsWith(this.CommandPrefix, StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Parse the Zpl Command
+        /// </summary>
+        /// <param name="zplCommand"></param>
+        public abstract void ParseCommand(string zplCommand);
+    }
+}

--- a/src/BinaryKits.Zpl.Protocol/Commands/CommandBase.cs
+++ b/src/BinaryKits.Zpl.Protocol/Commands/CommandBase.cs
@@ -129,6 +129,28 @@ namespace BinaryKits.Zpl.Protocol.Commands
         }
 
         /// <summary>
+        /// Get Zpl char for error correction level
+        /// </summary>
+        /// <param name="errorCorrectionLevel"></param>
+        /// <returns></returns>
+        public string RenderErrorCorrectionLevel(ErrorCorrectionLevel errorCorrectionLevel)
+        {
+            switch (errorCorrectionLevel)
+            {
+                case ErrorCorrectionLevel.UltraHighReliability:
+                    return "H";
+                case ErrorCorrectionLevel.HighReliability:
+                    return "Q";
+                case ErrorCorrectionLevel.Standard:
+                    return "M";
+                case ErrorCorrectionLevel.HighDensity:
+                    return "L";
+            }
+
+            throw new NotImplementedException("Unknown Error Correction Level");
+        }
+
+        /// <summary>
         /// Get boolean from ZPL Char
         /// </summary>
         /// <param name="value"></param>
@@ -170,6 +192,29 @@ namespace BinaryKits.Zpl.Protocol.Commands
 
             //Fallback
             return Orientation.Normal;
+        }
+
+        /// <summary>
+        /// Get error correction level from Zpl char
+        /// </summary>
+        /// <param name="errorCorrectionLevel"></param>
+        /// <returns></returns>
+        protected ErrorCorrectionLevel ConvertErrorCorrectionLevel(string errorCorrectionLevel)
+        {
+            switch (errorCorrectionLevel)
+            {
+                case "H":
+                    return ErrorCorrectionLevel.UltraHighReliability;
+                case "Q":
+                    return ErrorCorrectionLevel.HighReliability;
+                case "M":
+                    return ErrorCorrectionLevel.Standard;
+                case "L":
+                    return ErrorCorrectionLevel.HighDensity;
+            }
+
+            //Fallback
+            return ErrorCorrectionLevel.HighReliability;
         }
     }
 }

--- a/src/BinaryKits.Zpl.Protocol/Commands/CommandBase.cs
+++ b/src/BinaryKits.Zpl.Protocol/Commands/CommandBase.cs
@@ -151,6 +151,28 @@ namespace BinaryKits.Zpl.Protocol.Commands
         }
 
         /// <summary>
+        /// Get Zpl char for text justification
+        /// </summary>
+        /// <param name="textJustification"></param>
+        /// <returns></returns>
+        public string RenderTextJustification(TextJustification textJustification)
+        {
+            switch (textJustification)
+            {
+                case TextJustification.Left:
+                    return "L";
+                case TextJustification.Center:
+                    return "C";
+                case TextJustification.Right:
+                    return "R";
+                case TextJustification.Justified:
+                    return "J";
+            }
+
+            throw new NotImplementedException("Unknown Text Justification");
+        }
+
+        /// <summary>
         /// Get boolean from ZPL Char
         /// </summary>
         /// <param name="value"></param>

--- a/src/BinaryKits.Zpl.Protocol/Commands/CommandBase.cs
+++ b/src/BinaryKits.Zpl.Protocol/Commands/CommandBase.cs
@@ -97,47 +97,79 @@ namespace BinaryKits.Zpl.Protocol.Commands
         }
 
         /// <summary>
-        /// Get Zpl char for field orientation
+        /// Render Zpl char for boolean
         /// </summary>
-        /// <param name="fieldOrientation"></param>
+        /// <param name="value"></param>
         /// <returns></returns>
-        protected string RenderFieldOrientation(FieldOrientation fieldOrientation)
+        public string RenderBoolean(bool value)
         {
-            switch (fieldOrientation)
-            {
-                case FieldOrientation.Normal:
-                    return "N";
-                case FieldOrientation.Rotated90:
-                    return "R";
-                case FieldOrientation.Rotated180:
-                    return "I";
-                case FieldOrientation.Rotated270:
-                    return "B";
-            }
-
-            throw new NotImplementedException("Unknown Field Orientation");
+            return value ? "Y" : "N";
         }
 
         /// <summary>
-        /// Get Field orientation from Zpl char
+        /// Get Zpl char for orientation
         /// </summary>
-        /// <param name="fieldOrientation"></param>
+        /// <param name="orientation"></param>
         /// <returns></returns>
-        protected FieldOrientation ConvertFieldOrientation(string fieldOrientation)
+        protected string RenderOrientation(Orientation orientation)
         {
-            switch (fieldOrientation)
+            switch (orientation)
             {
-                case "N":
-                    return FieldOrientation.Normal;
-                case "R":
-                    return FieldOrientation.Rotated90;
-                case "I":
-                    return FieldOrientation.Rotated180;
-                case "B":
-                    return FieldOrientation.Rotated270;
+                case Orientation.Normal:
+                    return "N";
+                case Orientation.Rotated90:
+                    return "R";
+                case Orientation.Rotated180:
+                    return "I";
+                case Orientation.Rotated270:
+                    return "B";
             }
 
-            return FieldOrientation.Normal;
+            throw new NotImplementedException("Unknown Orientation");
+        }
+
+        /// <summary>
+        /// Get boolean from ZPL Char
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public bool ConvertBoolean(string value)
+        {
+            if (value == "Y")
+            {
+                return true;
+            }
+
+            if (value == "N")
+            {
+                return false;
+            }
+
+            //Fallback
+            return false;
+        }
+
+        /// <summary>
+        /// Get orientation from Zpl char
+        /// </summary>
+        /// <param name="orientation"></param>
+        /// <returns></returns>
+        protected Orientation ConvertOrientation(string orientation)
+        {
+            switch (orientation)
+            {
+                case "N":
+                    return Orientation.Normal;
+                case "R":
+                    return Orientation.Rotated90;
+                case "I":
+                    return Orientation.Rotated180;
+                case "B":
+                    return Orientation.Rotated270;
+            }
+
+            //Fallback
+            return Orientation.Normal;
         }
     }
 }

--- a/src/BinaryKits.Zpl.Protocol/Commands/CommandBase.cs
+++ b/src/BinaryKits.Zpl.Protocol/Commands/CommandBase.cs
@@ -79,7 +79,7 @@ namespace BinaryKits.Zpl.Protocol.Commands
         }
 
         /// <summary>
-        /// Get Zpl Line color
+        /// Get Zpl char for line color
         /// </summary>
         /// <param name="lineColor"></param>
         /// <returns></returns>
@@ -94,6 +94,50 @@ namespace BinaryKits.Zpl.Protocol.Commands
             }
 
             throw new NotImplementedException("Unknown Line Color");
+        }
+
+        /// <summary>
+        /// Get Zpl char for field orientation
+        /// </summary>
+        /// <param name="fieldOrientation"></param>
+        /// <returns></returns>
+        protected string RenderFieldOrientation(FieldOrientation fieldOrientation)
+        {
+            switch (fieldOrientation)
+            {
+                case FieldOrientation.Normal:
+                    return "N";
+                case FieldOrientation.Rotated90:
+                    return "R";
+                case FieldOrientation.Rotated180:
+                    return "I";
+                case FieldOrientation.Rotated270:
+                    return "B";
+            }
+
+            throw new NotImplementedException("Unknown Field Orientation");
+        }
+
+        /// <summary>
+        /// Get Field orientation from Zpl char
+        /// </summary>
+        /// <param name="fieldOrientation"></param>
+        /// <returns></returns>
+        protected FieldOrientation ConvertFieldOrientation(string fieldOrientation)
+        {
+            switch (fieldOrientation)
+            {
+                case "N":
+                    return FieldOrientation.Normal;
+                case "R":
+                    return FieldOrientation.Rotated90;
+                case "I":
+                    return FieldOrientation.Rotated180;
+                case "B":
+                    return FieldOrientation.Rotated270;
+            }
+
+            return FieldOrientation.Normal;
         }
     }
 }

--- a/src/BinaryKits.Zpl.Protocol/Commands/CommandBase.cs
+++ b/src/BinaryKits.Zpl.Protocol/Commands/CommandBase.cs
@@ -216,5 +216,28 @@ namespace BinaryKits.Zpl.Protocol.Commands
             //Fallback
             return ErrorCorrectionLevel.HighReliability;
         }
+
+        /// <summary>
+        /// Get the index of the specified character on the specified occurrence
+        /// </summary>
+        /// <param name="input"></param>
+        /// <param name="occurranceToFind"></param>
+        /// <param name="charToFind"></param>
+        /// <returns></returns>
+        protected int IndexOfNthCharacter(string input, int occurranceToFind, char charToFind)
+        {
+            var index = -1;
+            for (var i = 0; i < occurranceToFind; i++)
+            {
+                index = input.IndexOf(charToFind, index + 1);
+
+                if (index == -1)
+                {
+                    break;
+                }
+            }
+
+            return index;
+        }
     }
 }

--- a/src/BinaryKits.Zpl.Protocol/Commands/CommandBase.cs
+++ b/src/BinaryKits.Zpl.Protocol/Commands/CommandBase.cs
@@ -54,5 +54,46 @@ namespace BinaryKits.Zpl.Protocol.Commands
         /// </summary>
         /// <param name="zplCommand"></param>
         public abstract void ParseCommand(string zplCommand);
+
+        /// <summary>
+        /// Validate integer paramter
+        /// </summary>
+        /// <param name="parameterName"></param>
+        /// <param name="number"></param>
+        /// <param name="minimumValue"></param>
+        /// <param name="maximumValue"></param>
+        /// <returns></returns>
+        protected bool ValidateIntParameter(string parameterName, int? number, int minimumValue, int maximumValue)
+        {
+            if (number.HasValue)
+            {
+                if (number.Value < minimumValue || number.Value > maximumValue)
+                {
+                    throw new ArgumentException($"Must be between {minimumValue} and {maximumValue}", parameterName);
+                }
+
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Get Zpl Line color
+        /// </summary>
+        /// <param name="lineColor"></param>
+        /// <returns></returns>
+        protected string RenderLineColor(LineColor lineColor)
+        {
+            switch (lineColor)
+            {
+                case LineColor.Black:
+                    return "B";
+                case LineColor.White:
+                    return "W";
+            }
+
+            throw new NotImplementedException("Unknown Line Color");
+        }
     }
 }

--- a/src/BinaryKits.Zpl.Protocol/Commands/CommentCommand.cs
+++ b/src/BinaryKits.Zpl.Protocol/Commands/CommentCommand.cs
@@ -1,0 +1,45 @@
+﻿namespace BinaryKits.Zpl.Protocol.Commands
+{
+    /// <summary>
+    /// Comment<br/>
+    /// The ^FX command is useful when you want to add non-printing informational comments or statements
+    /// within a label format.Any data after the ^FX command up to the next caret (^) or tilde(~) command does
+    /// not have any effect on the label format.Therefore, you should avoid using the caret(^) or tilde(~)
+    /// commands within the ^FX statement.
+    /// </summary>
+    public class CommentCommand : CommandBase
+    {
+        /// <summary>
+        /// Non printing comment
+        /// </summary>
+        public string NonPrintingComment { get; private set; }
+
+        /// <summary>
+        /// Comment
+        /// </summary>
+        public CommentCommand() : base("^FX")
+        { }
+
+        /// <summary>
+        /// Comment
+        /// </summary>
+        /// <param name="nonPrintingComment">non printing comment</param>
+        public CommentCommand(string nonPrintingComment = null)
+            : this()
+        {
+            this.NonPrintingComment = nonPrintingComment;
+        }
+
+        ///<inheritdoc/>
+        public override string ToZpl()
+        {
+            return $"{this.CommandPrefix}{this.NonPrintingComment}";
+        }
+
+        ///<inheritdoc/>
+        public override void ParseCommand(string zplCommand)
+        {
+            this.NonPrintingComment = zplCommand.Substring(this.CommandPrefix.Length);
+        }
+    }
+}

--- a/src/BinaryKits.Zpl.Protocol/Commands/DownloadGraphicsCommand.cs
+++ b/src/BinaryKits.Zpl.Protocol/Commands/DownloadGraphicsCommand.cs
@@ -11,9 +11,9 @@ namespace BinaryKits.Zpl.Protocol.Commands
     public class DownloadGraphicsCommand : CommandBase
     {
         /// <summary>
-        /// Device to store image
+        /// Storage device
         /// </summary>
-        public string DeviceToStoreImage { get; private set; } = "R:";
+        public string StorageDevice { get; private set; } = "R:";
 
         /// <summary>
         /// Image name
@@ -44,22 +44,22 @@ namespace BinaryKits.Zpl.Protocol.Commands
         /// <summary>
         /// Download Graphics
         /// </summary>
-        /// <param name="deviceToStoreImage">Device to store image</param>
+        /// <param name="storageDevice">Storage device</param>
         /// <param name="imageName">Image name</param>
         /// <param name="totalNumberOfBytesInGraphic">Total number of bytes in graphic</param>
         /// <param name="numberOfBytesPerRow">Number of bytes per row</param>
         /// <param name="data">ASCII hexadecimal string defining image</param>
         public DownloadGraphicsCommand(
-            string deviceToStoreImage,
+            string storageDevice,
             string imageName,
             int totalNumberOfBytesInGraphic,
             int numberOfBytesPerRow,
             string data)
             : this()
         {
-            this.ValidateDeviceToStoreImage(deviceToStoreImage);
+            this.ValidateDeviceToStoreImage(storageDevice);
 
-            this.DeviceToStoreImage = deviceToStoreImage;
+            this.StorageDevice = storageDevice;
             this.ImageName = imageName;
             this.TotalNumberOfBytesInGraphic = totalNumberOfBytesInGraphic;
             this.NumberOfBytesPerRow = numberOfBytesPerRow;
@@ -89,7 +89,7 @@ namespace BinaryKits.Zpl.Protocol.Commands
         ///<inheritdoc/>
         public override string ToZpl()
         {
-            return $"{this.CommandPrefix}{this.DeviceToStoreImage}{this.ImageName},{this.TotalNumberOfBytesInGraphic},{this.NumberOfBytesPerRow},{this.Data}";
+            return $"{this.CommandPrefix}{this.StorageDevice}{this.ImageName},{this.TotalNumberOfBytesInGraphic},{this.NumberOfBytesPerRow},{this.Data}";
         }
 
         ///<inheritdoc/>
@@ -99,7 +99,7 @@ namespace BinaryKits.Zpl.Protocol.Commands
 
             if (zplDataParts.Length > 0)
             {
-                this.DeviceToStoreImage = zplDataParts[0].Substring(0, 2);
+                this.StorageDevice = zplDataParts[0].Substring(0, 2);
                 var imageName = zplDataParts[0].Substring(2);
 
                 if (!string.IsNullOrEmpty(imageName))

--- a/src/BinaryKits.Zpl.Protocol/Commands/DownloadGraphicsCommand.cs
+++ b/src/BinaryKits.Zpl.Protocol/Commands/DownloadGraphicsCommand.cs
@@ -1,0 +1,110 @@
+﻿namespace BinaryKits.Zpl.Protocol.Commands
+{
+    /// <summary>
+    /// Download Graphics<br/>
+    /// The ~DG command downloads an ASCII Hex representation of a graphic image. If .GRF is not the specified
+    /// file extension, .GRF is automatically appended.
+    /// </summary>
+    public class DownloadGraphicsCommand : CommandBase
+    {
+        /// <summary>
+        /// Device to store image
+        /// </summary>
+        public string DeviceToStoreImage { get; private set; } = "R:";
+
+        /// <summary>
+        /// Image name
+        /// </summary>
+        public string ImageName { get; private set; } = "UNKNOWN.GRF";
+
+        /// <summary>
+        /// Total number of bytes in graphic
+        /// </summary>
+        public int TotalNumberOfBytesInGraphic { get; private set; }
+
+        /// <summary>
+        /// Number of bytes per row
+        /// </summary>
+        public int NumberOfBytesPerRow { get; private set; }
+
+        /// <summary>
+        /// ASCII hexadecimal string defining image
+        /// </summary>
+        public string Data { get; private set; }
+
+        /// <summary>
+        /// Download Graphics
+        /// </summary>
+        public DownloadGraphicsCommand() : base("~DG")
+        { }
+
+        /// <summary>
+        /// Download Graphics
+        /// </summary>
+        /// <param name="deviceToStoreImage">Device to store image</param>
+        /// <param name="imageName">Image name</param>
+        /// <param name="totalNumberOfBytesInGraphic">Total number of bytes in graphic</param>
+        /// <param name="numberOfBytesPerRow">Number of bytes per row</param>
+        /// <param name="data">ASCII hexadecimal string defining image</param>
+        public DownloadGraphicsCommand(
+            string deviceToStoreImage,
+            string imageName,
+            int totalNumberOfBytesInGraphic,
+            int numberOfBytesPerRow,
+            string data)
+            : this()
+        {
+            this.DeviceToStoreImage = deviceToStoreImage;
+            this.ImageName = imageName;
+            this.TotalNumberOfBytesInGraphic = totalNumberOfBytesInGraphic;
+            this.NumberOfBytesPerRow = numberOfBytesPerRow;
+            this.Data = data;
+        }
+
+        ///<inheritdoc/>
+        public override string ToZpl()
+        {
+            return $"{this.CommandPrefix}{this.DeviceToStoreImage}{this.ImageName},{this.TotalNumberOfBytesInGraphic},{this.NumberOfBytesPerRow},{this.Data}";
+        }
+
+        ///<inheritdoc/>
+        public override void ParseCommand(string zplCommand)
+        {
+            var zplDataParts = this.SplitCommand(zplCommand);
+
+            if (zplDataParts.Length > 0)
+            {
+                this.DeviceToStoreImage = zplDataParts[0].Substring(0, 2);
+                var imageName = zplDataParts[0].Substring(2);
+
+                if (!string.IsNullOrEmpty(imageName))
+                {
+                    this.ImageName = imageName;
+                }
+            }
+
+            if (zplDataParts.Length > 1)
+            {
+                if (int.TryParse(zplDataParts[1], out var totalNumberOfBytesInGraphic))
+                {
+                    this.TotalNumberOfBytesInGraphic = totalNumberOfBytesInGraphic;
+                }
+            }
+
+            if (zplDataParts.Length > 2)
+            {
+                if (int.TryParse(zplDataParts[2], out var numberOfBytesPerRow))
+                {
+                    this.NumberOfBytesPerRow = numberOfBytesPerRow;
+                }
+            }
+
+            //Third comma is the start of the image data
+            var indexOfThirdComma = this.IndexOfNthCharacter(zplCommand, 3, ',');
+            if (indexOfThirdComma != -1)
+            {
+                this.Data = zplCommand.Substring(indexOfThirdComma + 1);
+            }
+        }
+    }
+}

--- a/src/BinaryKits.Zpl.Protocol/Commands/DownloadGraphicsCommand.cs
+++ b/src/BinaryKits.Zpl.Protocol/Commands/DownloadGraphicsCommand.cs
@@ -1,4 +1,7 @@
-﻿namespace BinaryKits.Zpl.Protocol.Commands
+﻿using System;
+using System.Linq;
+
+namespace BinaryKits.Zpl.Protocol.Commands
 {
     /// <summary>
     /// Download Graphics<br/>
@@ -54,11 +57,33 @@
             string data)
             : this()
         {
+            this.ValidateDeviceToStoreImage(deviceToStoreImage);
+
             this.DeviceToStoreImage = deviceToStoreImage;
             this.ImageName = imageName;
             this.TotalNumberOfBytesInGraphic = totalNumberOfBytesInGraphic;
             this.NumberOfBytesPerRow = numberOfBytesPerRow;
             this.Data = data;
+        }
+
+        private void ValidateDeviceToStoreImage(string deviceToStoreImage)
+        {
+            if (deviceToStoreImage.Length != 2)
+            {
+                throw new ArgumentException($"Invalid format requires 2 characters", deviceToStoreImage);
+            }
+
+            var allowedDevices = new char[] { 'R', 'E', 'B', 'A' };
+
+            if (!allowedDevices.Contains(deviceToStoreImage[0]))
+            {
+                throw new ArgumentException($"Invalid device letter", deviceToStoreImage);
+            }
+
+            if (deviceToStoreImage[1] != ':')
+            {
+                throw new ArgumentException($"The second character must be a colon", deviceToStoreImage);
+            }
         }
 
         ///<inheritdoc/>

--- a/src/BinaryKits.Zpl.Protocol/Commands/DownloadObjectsCommand.cs
+++ b/src/BinaryKits.Zpl.Protocol/Commands/DownloadObjectsCommand.cs
@@ -1,0 +1,142 @@
+﻿namespace BinaryKits.Zpl.Protocol.Commands
+{
+    /// <summary>
+    /// Download Objects<br/>
+    /// The ~DY command downloads to the printer graphic objects or fonts in any supported format. This
+    /// command can be used in place of ~DG for more saving and loading options. ~DY is the preferred command
+    /// to download TrueType fonts on printers with firmware later than X.13. It is faster than ~DU. The ~DY
+    /// command also supports downloading wireless certificate files.
+    /// </summary>
+    public class DownloadObjectsCommand : CommandBase
+    {
+        /// <summary>
+        /// Storage device (file location)
+        /// </summary>
+        public string StorageDevice { get; private set; } = "R:";
+
+        /// <summary>
+        /// File name
+        /// </summary>
+        public string FileName { get; private set; } = "UNKNOWN";
+
+        /// <summary>
+        /// Format downloaded in data field
+        /// </summary>
+        public char FormatDownloadedInDataField { get; private set; }
+
+        /// <summary>
+        /// Extension of stored file
+        /// </summary>
+        public string ExtensionOfStoredFile { get; private set; }
+
+        /// <summary>
+        /// Total number of bytes in file
+        /// </summary>
+        public int TotalNumberOfBytesInFile { get; private set; }
+
+        /// <summary>
+        /// Total number of bytes per row
+        /// </summary>
+        public int TotalNumberOfBytesPerRow { get; private set; }
+
+        /// <summary>
+        /// Data
+        /// </summary>
+        public string Data { get; private set; }
+
+        /// <summary>
+        /// Download Objects
+        /// </summary>
+        public DownloadObjectsCommand() : base("~DY")
+        { }
+
+        /// <summary>
+        /// Download Objects
+        /// </summary>
+        /// <param name="storageDevice">Storage device</param>
+        /// <param name="fileName">File name</param>
+        /// <param name="formatDownloadedInDataField">Format downloaded in data field</param>
+        /// <param name="extensionOfStoredFile">Extension of stored file</param>
+        /// <param name="totalNumberOfBytesInFile">Total number of bytes in file</param>
+        /// <param name="totalNumberOfBytesPerRow">Total number of bytes per row</param>
+        /// <param name="data">Data</param>
+        public DownloadObjectsCommand(
+            string storageDevice,
+            string fileName,
+            char formatDownloadedInDataField,
+            string extensionOfStoredFile,
+            int totalNumberOfBytesInFile,
+            int totalNumberOfBytesPerRow,
+            string data)
+            : this()
+        {
+            this.StorageDevice = storageDevice;
+            this.FileName = fileName;
+            this.FormatDownloadedInDataField = formatDownloadedInDataField;
+            this.ExtensionOfStoredFile = extensionOfStoredFile;
+            this.TotalNumberOfBytesInFile = totalNumberOfBytesInFile;
+            this.TotalNumberOfBytesPerRow = totalNumberOfBytesPerRow;
+            this.Data = data;
+        }
+
+        ///<inheritdoc/>
+        public override string ToZpl()
+        {
+            return $"{this.CommandPrefix}{this.StorageDevice}{this.FileName},{this.FormatDownloadedInDataField},{this.ExtensionOfStoredFile},{this.TotalNumberOfBytesInFile},{this.TotalNumberOfBytesPerRow},{this.Data}";
+        }
+
+        ///<inheritdoc/>
+        public override void ParseCommand(string zplCommand)
+        {
+            if (zplCommand.Length <= 4)
+            {
+                return;
+            }
+
+            this.StorageDevice = zplCommand.Substring(this.CommandPrefix.Length, 2);
+
+            var zplDataParts = this.SplitCommand(zplCommand, 2);
+
+            if (zplDataParts.Length > 0)
+            {
+                var fileName = zplDataParts[0];
+
+                if (!string.IsNullOrEmpty(fileName))
+                {
+                    this.FileName = zplDataParts[0];
+                }
+            }
+
+            if (zplDataParts.Length > 1)
+            {
+                this.FormatDownloadedInDataField = zplDataParts[1][0];
+            }
+
+            if (zplDataParts.Length > 2)
+            {
+                this.ExtensionOfStoredFile = zplDataParts[2];
+            }
+
+            if (zplDataParts.Length > 3)
+            {
+                if (int.TryParse(zplDataParts[3], out var totalNumberOfBytesInFile))
+                {
+                    this.TotalNumberOfBytesInFile = totalNumberOfBytesInFile;
+                }
+            }
+
+            if (zplDataParts.Length > 4)
+            {
+                if (int.TryParse(zplDataParts[4], out var totalNumberOfBytesPerRow))
+                {
+                    this.TotalNumberOfBytesPerRow = totalNumberOfBytesPerRow;
+                }
+            }
+
+            if (zplDataParts.Length > 5)
+            {
+                this.Data = zplDataParts[5];
+            }
+        }
+    }
+}

--- a/src/BinaryKits.Zpl.Protocol/Commands/FieldBlockCommand.cs
+++ b/src/BinaryKits.Zpl.Protocol/Commands/FieldBlockCommand.cs
@@ -1,0 +1,134 @@
+﻿namespace BinaryKits.Zpl.Protocol.Commands
+{
+    /// <summary>
+    /// FieldBlock<br/>
+    /// The ^FB command allows you to print text into a defined block type format. This command formats an ^FD
+    /// or ^SN string into a block of text using the origin, font, and rotation specified for the text string. The ^FB
+    /// command also contains an automatic word-wrap function.
+    /// </summary>
+    public class FieldBlockCommand : CommandBase
+    {
+        /// <summary>
+        /// Width of text block line
+        /// </summary>
+        public int WidthOfTextBlockLine { get; private set; }
+
+        /// <summary>
+        /// Maximum number of lines in text block
+        /// </summary>
+        public int MaximumNumberOfLinesInTextBlock { get; private set; } = 1;
+
+        /// <summary>
+        /// Add or delete space between lines
+        /// </summary>
+        public int AddOrDeleteSpaceBetweenLines { get; private set; }
+
+        /// <summary>
+        /// Text justification
+        /// </summary>
+        public TextJustification TextJustification { get; private set; } = TextJustification.Left;
+
+        /// <summary>
+        /// Hanging indent of the second and remaining lines
+        /// </summary>
+        public int HangingIndentOfTheSecondAndRemainingLines { get; private set; }
+
+        /// <summary>
+        /// Field Block
+        /// </summary>
+        public FieldBlockCommand() : base("^FB")
+        { }
+
+        /// <summary>
+        /// Field Block
+        /// </summary>
+        /// <param name="widthOfTextBlockLine">Width of text block line</param>
+        /// <param name="maximumNumberOfLinesInTextBlock">Maximum number of lines in text block</param>
+        /// <param name="addOrDeleteSpaceBetweenLines">Add or delete space between lines</param>
+        /// <param name="textJustification">Text justification</param>
+        /// <param name="hangingIndentOfTheSecondAndRemainingLines">Hanging indent of the second and remaining lines</param>
+        public FieldBlockCommand(
+            int widthOfTextBlockLine = 0,
+            int maximumNumberOfLinesInTextBlock = 1,
+            int addOrDeleteSpaceBetweenLines = 0,
+            TextJustification textJustification = TextJustification.Left,
+            int hangingIndentOfTheSecondAndRemainingLines = 0)
+            : this()
+        {
+            this.WidthOfTextBlockLine = widthOfTextBlockLine;
+
+            if (this.ValidateIntParameter(nameof(maximumNumberOfLinesInTextBlock), maximumNumberOfLinesInTextBlock, 1, 9999))
+            {
+                this.MaximumNumberOfLinesInTextBlock = maximumNumberOfLinesInTextBlock;
+            }
+
+            if (this.ValidateIntParameter(nameof(addOrDeleteSpaceBetweenLines), addOrDeleteSpaceBetweenLines, -9999, 9999))
+            {
+                this.AddOrDeleteSpaceBetweenLines = addOrDeleteSpaceBetweenLines;
+            }
+
+            this.TextJustification = textJustification;
+
+            if (this.ValidateIntParameter(nameof(hangingIndentOfTheSecondAndRemainingLines), hangingIndentOfTheSecondAndRemainingLines, 0, 9999))
+            {
+                this.HangingIndentOfTheSecondAndRemainingLines = hangingIndentOfTheSecondAndRemainingLines;
+            }
+        }
+
+        ///<inheritdoc/>
+        public override string ToZpl()
+        {
+            return $"{this.CommandPrefix}{this.WidthOfTextBlockLine},{this.MaximumNumberOfLinesInTextBlock},{this.AddOrDeleteSpaceBetweenLines},{this.RenderTextJustification(this.TextJustification)},{this.HangingIndentOfTheSecondAndRemainingLines}";
+        }
+
+        ///<inheritdoc/>
+        public override void ParseCommand(string zplCommand)
+        {
+            var zplDataParts = this.SplitCommand(zplCommand);
+
+            if (zplDataParts.Length > 0)
+            {
+                if (int.TryParse(zplDataParts[0], out var widthOfTextBlockLine))
+                {
+                    this.WidthOfTextBlockLine = widthOfTextBlockLine;
+                }
+            }
+            if (zplDataParts.Length > 1)
+            {
+                if (int.TryParse(zplDataParts[1], out var maximumNumberOfLinesInTextBlock))
+                {
+                    this.MaximumNumberOfLinesInTextBlock = maximumNumberOfLinesInTextBlock;
+                }
+            }
+            if (zplDataParts.Length > 2)
+            {
+                if (int.TryParse(zplDataParts[2], out var addOrDeleteSpaceBetweenLines))
+                {
+                    this.AddOrDeleteSpaceBetweenLines = addOrDeleteSpaceBetweenLines;
+                }
+            }
+            if (zplDataParts.Length > 3)
+            {
+                switch (zplDataParts[3])
+                {
+                    case "C":
+                        this.TextJustification = TextJustification.Center;
+                        break;
+                    case "R":
+                        this.TextJustification = TextJustification.Right;
+                        break;
+                    case "J":
+                        this.TextJustification = TextJustification.Justified;
+                        break;
+                }
+            }
+            if (zplDataParts.Length > 4)
+            {
+                if (int.TryParse(zplDataParts[4], out var hangingIndentOfTheSecondAndRemainingLines))
+                {
+                    this.HangingIndentOfTheSecondAndRemainingLines = hangingIndentOfTheSecondAndRemainingLines;
+                }
+            }
+        }
+    }
+}

--- a/src/BinaryKits.Zpl.Protocol/Commands/FieldDataCommand.cs
+++ b/src/BinaryKits.Zpl.Protocol/Commands/FieldDataCommand.cs
@@ -1,0 +1,43 @@
+﻿namespace BinaryKits.Zpl.Protocol.Commands
+{
+    /// <summary>
+    /// Field Data<br/>
+    /// The ^FD command defines the data string for a field. The field data can be any printable character except
+    /// those used as command prefixes(^ and ~).
+    /// </summary>
+    public class FieldDataCommand : CommandBase
+    {
+        /// <summary>
+        /// Data to be printed
+        /// </summary>
+        public string Data { get; private set; }
+
+        /// <summary>
+        /// Field Data
+        /// </summary>
+        public FieldDataCommand() : base("^FD")
+        { }
+
+        /// <summary>
+        /// Field Data
+        /// </summary>
+        /// <param name="data">Data to be printed</param>
+        public FieldDataCommand(string data = null)
+            : this()
+        {
+            this.Data = data;
+        }
+
+        ///<inheritdoc/>
+        public override string ToZpl()
+        {
+            return $"{this.CommandPrefix}{this.Data}";
+        }
+
+        ///<inheritdoc/>
+        public override void ParseCommand(string zplCommand)
+        {
+            this.Data = zplCommand.Substring(this.CommandPrefix.Length);
+        }
+    }
+}

--- a/src/BinaryKits.Zpl.Protocol/Commands/FieldOriginCommand.cs
+++ b/src/BinaryKits.Zpl.Protocol/Commands/FieldOriginCommand.cs
@@ -1,9 +1,7 @@
-﻿using System;
-
-namespace BinaryKits.Zpl.Protocol.Commands
+﻿namespace BinaryKits.Zpl.Protocol.Commands
 {
     /// <summary>
-    /// Field Origin
+    /// Field Origin<br/>
     /// The ^FO command sets a field origin, relative to the label home (^LH) position. ^FO sets the upper-left 
     /// corner of the field area by defining points along the x-axis and y-axis independent of the rotation.
     /// </summary>
@@ -30,25 +28,18 @@ namespace BinaryKits.Zpl.Protocol.Commands
         /// </summary>
         /// <param name="x">x-axis location (0 to 32000)</param>
         /// <param name="y">y-axis location (0 to 32000)</param>
-        public FieldOriginCommand(int? x = null, int? y = null) : this()
+        public FieldOriginCommand(
+            int? x = null,
+            int? y = null)
+            : this()
         {
-            if (x.HasValue)
+            if (this.ValidateIntParameter(nameof(x), x, 0, 32000))
             {
-                if (x < 0 || x > 32000)
-                {
-                    throw new ArgumentException("Must be between 0 and 32000", nameof(x));
-                }
-
                 this.X = x.Value;
             }
 
-            if (y.HasValue)
+            if (this.ValidateIntParameter(nameof(y), y, 0, 32000))
             {
-                if (y < 0 || y > 32000)
-                {
-                    throw new ArgumentException("Must be between 0 and 32000", nameof(y));
-                }
-
                 this.Y = y.Value;
             }
         }

--- a/src/BinaryKits.Zpl.Protocol/Commands/FieldOriginCommand.cs
+++ b/src/BinaryKits.Zpl.Protocol/Commands/FieldOriginCommand.cs
@@ -1,0 +1,84 @@
+﻿using System;
+
+namespace BinaryKits.Zpl.Protocol.Commands
+{
+    /// <summary>
+    /// Field Origin
+    /// The ^FO command sets a field origin, relative to the label home (^LH) position. ^FO sets the upper-left 
+    /// corner of the field area by defining points along the x-axis and y-axis independent of the rotation.
+    /// </summary>
+    public class FieldOriginCommand : CommandBase
+    {
+        /// <summary>
+        /// X-axis location
+        /// </summary>
+        public int X { get; private set; } = 0;
+
+        /// <summary>
+        /// Y-axis location
+        /// </summary>
+        public int Y { get; private set; } = 0;
+
+        /// <summary>
+        /// Field Origin
+        /// </summary>
+        public FieldOriginCommand() : base("^FO")
+        { }
+
+        /// <summary>
+        /// Field Origin
+        /// </summary>
+        /// <param name="x">x-axis location (0 to 32000)</param>
+        /// <param name="y">y-axis location (0 to 32000)</param>
+        public FieldOriginCommand(int? x = null, int? y = null) : this()
+        {
+            if (x.HasValue)
+            {
+                if (x < 0 || x > 32000)
+                {
+                    throw new ArgumentException("Must be between 0 and 32000", nameof(x));
+                }
+
+                this.X = x.Value;
+            }
+
+            if (y.HasValue)
+            {
+                if (y < 0 || y > 32000)
+                {
+                    throw new ArgumentException("Must be between 0 and 32000", nameof(y));
+                }
+
+                this.Y = y.Value;
+            }
+        }
+
+        ///<inheritdoc/>
+        public override string ToZpl()
+        {
+            return $"{this.CommandPrefix}{this.X},{this.Y}";
+        }
+
+        ///<inheritdoc/>
+        public override void ParseCommand(string zplCommand)
+        {
+            var zplDataParts = this.SplitCommand(zplCommand);
+
+            if (zplDataParts.Length > 0)
+            {
+                if (int.TryParse(zplDataParts[0], out var x))
+                {
+                    this.X = x;
+                }
+            }
+
+            if (zplDataParts.Length > 1)
+            {
+                if (int.TryParse(zplDataParts[1], out var y))
+                {
+                    this.Y = y;
+                }
+            }
+        }
+    }
+}

--- a/src/BinaryKits.Zpl.Protocol/Commands/FieldReversePrintCommand.cs
+++ b/src/BinaryKits.Zpl.Protocol/Commands/FieldReversePrintCommand.cs
@@ -1,0 +1,27 @@
+﻿namespace BinaryKits.Zpl.Protocol.Commands
+{
+    /// <summary>
+    /// Field Reverse Print<br/>
+    /// The ^FR command allows a field to appear as white over black or black over white. When printing a field
+    /// and the ^FR command has been used, the color of the output is the reverse of its background.
+    /// </summary>
+    public class FieldReversePrintCommand : CommandBase
+    {
+        /// <summary>
+        /// Field Reverse Print
+        /// </summary>
+        public FieldReversePrintCommand() : base("^FR")
+        { }
+
+        ///<inheritdoc/>
+        public override string ToZpl()
+        {
+            return $"{this.CommandPrefix}";
+        }
+
+        ///<inheritdoc/>
+        public override void ParseCommand(string zplCommand)
+        {
+        }
+    }
+}

--- a/src/BinaryKits.Zpl.Protocol/Commands/FieldSeperatorCommand.cs
+++ b/src/BinaryKits.Zpl.Protocol/Commands/FieldSeperatorCommand.cs
@@ -1,0 +1,27 @@
+﻿namespace BinaryKits.Zpl.Protocol.Commands
+{
+    /// <summary>
+    /// Field Separator<br/>
+    /// The ^FS command denotes the end of the field definition. Alternatively, ^FS command can also be issued
+    /// as a single ASCII control code SI(Control-O, hexadecimal 0F).
+    /// </summary>
+    public class FieldSeperatorCommand : CommandBase
+    {
+        /// <summary>
+        /// Field Separator
+        /// </summary>
+        public FieldSeperatorCommand() : base("^FS")
+        { }
+
+        ///<inheritdoc/>
+        public override string ToZpl()
+        {
+            return $"{this.CommandPrefix}";
+        }
+
+        ///<inheritdoc/>
+        public override void ParseCommand(string zplCommand)
+        {
+        }
+    }
+}

--- a/src/BinaryKits.Zpl.Protocol/Commands/FieldTypesetCommand.cs
+++ b/src/BinaryKits.Zpl.Protocol/Commands/FieldTypesetCommand.cs
@@ -1,0 +1,76 @@
+﻿namespace BinaryKits.Zpl.Protocol.Commands
+{
+    /// <summary>
+    /// Field Typeset<br/>
+    /// The ^FT command sets the field position, relative to the home position of the label designated by the ^LH
+    /// command.The typesetting origin of the field is fixed with respect to the contents of the field and does not
+    /// change with rotation.
+    /// </summary>
+    public class FieldTypesetCommand : CommandBase
+    {
+        /// <summary>
+        /// X-axis location
+        /// </summary>
+        public int X { get; private set; } = 0;
+
+        /// <summary>
+        /// Y-axis location
+        /// </summary>
+        public int Y { get; private set; } = 0;
+
+        /// <summary>
+        /// Field Typeset
+        /// </summary>
+        public FieldTypesetCommand() : base("^FT")
+        { }
+
+        /// <summary>
+        /// Field Typeset
+        /// </summary>
+        /// <param name="x">x-axis location (0 to 32000)</param>
+        /// <param name="y">y-axis location (0 to 32000)</param>
+        public FieldTypesetCommand(
+            int? x = null,
+            int? y = null)
+            : this()
+        {
+            if (this.ValidateIntParameter(nameof(x), x, 0, 32000))
+            {
+                this.X = x.Value;
+            }
+
+            if (this.ValidateIntParameter(nameof(y), y, 0, 32000))
+            {
+                this.Y = y.Value;
+            }
+        }
+
+        ///<inheritdoc/>
+        public override string ToZpl()
+        {
+            return $"{this.CommandPrefix}{this.X},{this.Y}";
+        }
+
+        ///<inheritdoc/>
+        public override void ParseCommand(string zplCommand)
+        {
+            var zplDataParts = this.SplitCommand(zplCommand);
+
+            if (zplDataParts.Length > 0)
+            {
+                if (int.TryParse(zplDataParts[0], out var x))
+                {
+                    this.X = x;
+                }
+            }
+
+            if (zplDataParts.Length > 1)
+            {
+                if (int.TryParse(zplDataParts[1], out var y))
+                {
+                    this.Y = y;
+                }
+            }
+        }
+    }
+}

--- a/src/BinaryKits.Zpl.Protocol/Commands/GraphicBoxCommand.cs
+++ b/src/BinaryKits.Zpl.Protocol/Commands/GraphicBoxCommand.cs
@@ -1,0 +1,141 @@
+﻿namespace BinaryKits.Zpl.Protocol.Commands
+{
+    /// <summary>
+    /// Graphic Box<br/>
+    /// The ^GB command is used to draw boxes and lines as part of a label format. Boxes and lines are used to
+    /// highlight important information, divide labels into distinct areas, or to improve the appearance of a label.
+    /// The same format command is used for drawing either boxes or lines.
+    /// </summary>
+    public class GraphicBoxCommand : CommandBase
+    {
+        /// <summary>
+        /// Box width
+        /// </summary>
+        public int BoxWidth { get; private set; } = 1;
+
+        /// <summary>
+        /// Box height
+        /// </summary>
+        public int BoxHeight { get; private set; } = 1;
+
+        /// <summary>
+        /// Border thickness
+        /// </summary>
+        public int BorderThickness { get; private set; } = 1;
+
+        /// <summary>
+        /// Line color
+        /// </summary>
+        public LineColor LineColor { get; private set; } = LineColor.Black;
+
+        /// <summary>
+        /// Degree of cornerrounding
+        /// </summary>
+        public int DegreeOfCornerrounding { get; private set; } = 0;
+
+        /// <summary>
+        /// Graphic Box
+        /// </summary>
+        public GraphicBoxCommand() : base("^GB")
+        { }
+
+        /// <summary>
+        /// Graphic Box
+        /// </summary>
+        /// <param name="boxWidth">Box width (borderThickness or 1 to 32000)</param>
+        /// <param name="boxHeight">Box height (borderThickness or 1 to 32000)</param>
+        /// <param name="borderThickness">Border thickness (1 to 32000)</param>
+        /// <param name="lineColor">Line color</param>
+        /// <param name="degreeOfCornerrounding">Degree of cornerrounding (0 to 8)</param>
+        public GraphicBoxCommand(
+            int? boxWidth = null,
+            int? boxHeight = null,
+            int? borderThickness = null,
+            LineColor lineColor = LineColor.Black,
+            int? degreeOfCornerrounding = null)
+            : this()
+        {
+            if (this.ValidateIntParameter(nameof(borderThickness), borderThickness, 1, 32000))
+            {
+                this.BorderThickness = borderThickness.Value;
+                this.BoxWidth = this.BorderThickness;
+                this.BoxHeight = this.BorderThickness;
+            }
+
+            if (this.ValidateIntParameter(nameof(boxWidth), boxWidth, this.BorderThickness, 32000))
+            {
+                this.BoxWidth = boxWidth.Value;
+            }
+
+            if (this.ValidateIntParameter(nameof(boxHeight), boxHeight, this.BorderThickness, 32000))
+            {
+                this.BoxHeight = boxHeight.Value;
+            }
+
+            this.LineColor = lineColor;
+
+            if (this.ValidateIntParameter(nameof(degreeOfCornerrounding), degreeOfCornerrounding, 0, 8))
+            {
+                this.DegreeOfCornerrounding = degreeOfCornerrounding.Value;
+            }
+        }
+
+        ///<inheritdoc/>
+        public override string ToZpl()
+        {
+            return $"{this.CommandPrefix}{this.BoxWidth},{this.BoxHeight},{this.BorderThickness},{this.RenderLineColor(this.LineColor)},{this.DegreeOfCornerrounding}";
+        }
+
+        ///<inheritdoc/>
+        public override void ParseCommand(string zplCommand)
+        {
+            var zplDataParts = this.SplitCommand(zplCommand);
+
+            if (zplDataParts.Length > 0)
+            {
+                if (int.TryParse(zplDataParts[0], out var boxWidth))
+                {
+                    this.BoxWidth = boxWidth;
+                }
+            }
+
+            if (zplDataParts.Length > 1)
+            {
+                if (int.TryParse(zplDataParts[1], out var boxHeight))
+                {
+                    this.BoxHeight = boxHeight;
+                }
+            }
+
+            if (zplDataParts.Length > 2)
+            {
+                if (int.TryParse(zplDataParts[2], out var borderThickness))
+                {
+                    this.BorderThickness = borderThickness;
+                    if (this.BoxWidth < borderThickness)
+                    {
+                        this.BoxWidth = borderThickness;
+                    }
+                    if (this.BoxHeight < borderThickness)
+                    {
+                        this.BoxHeight = borderThickness;
+                    }
+                }
+            }
+
+            if (zplDataParts.Length > 3)
+            {
+                var lineColorTemp = zplDataParts[3];
+                this.LineColor = lineColorTemp == "W" ? LineColor.White : LineColor.Black;
+            }
+
+            if (zplDataParts.Length > 4)
+            {
+                if (int.TryParse(zplDataParts[4], out var degreeOfCornerrounding))
+                {
+                    this.DegreeOfCornerrounding = degreeOfCornerrounding;
+                }
+            }
+        }
+    }
+}

--- a/src/BinaryKits.Zpl.Protocol/Commands/GraphicCircleCommand.cs
+++ b/src/BinaryKits.Zpl.Protocol/Commands/GraphicCircleCommand.cs
@@ -1,0 +1,90 @@
+﻿namespace BinaryKits.Zpl.Protocol.Commands
+{
+    /// <summary>
+    /// Graphic Circle<br/>
+    /// The ^GC command produces a circle on the printed label. The command parameters specify the diameter
+    /// (width) of the circle, outline thickness, and color. Thickness extends inward from the outline.
+    /// </summary>
+    public class GraphicCircleCommand : CommandBase
+    {
+        /// <summary>
+        /// Circle diameter
+        /// </summary>
+        public int CircleDiameter { get; private set; } = 3;
+
+        /// <summary>
+        /// Border thickness
+        /// </summary>
+        public int BorderThickness { get; private set; } = 1;
+
+        /// <summary>
+        /// Line color
+        /// </summary>
+        public LineColor LineColor { get; private set; } = LineColor.Black;
+
+        /// <summary>
+        /// Graphic Circle
+        /// </summary>
+        public GraphicCircleCommand() : base("^GC")
+        { }
+
+        /// <summary>
+        /// Graphic Circle
+        /// </summary>
+        /// <param name="circleDiameter">Circle diameter (3 to 4095)</param>
+        /// <param name="borderThickness">Border thickness (1 to 4095)</param>
+        /// <param name="lineColor">Line color</param>
+        public GraphicCircleCommand(
+            int? circleDiameter = null,
+            int? borderThickness = null,
+            LineColor lineColor = LineColor.Black)
+            : this()
+        {
+            if (this.ValidateIntParameter(nameof(circleDiameter), circleDiameter, 3, 4095))
+            {
+                this.CircleDiameter = circleDiameter.Value;
+            }
+
+            if (this.ValidateIntParameter(nameof(borderThickness), borderThickness, 1, 4095))
+            {
+                this.BorderThickness = borderThickness.Value;
+            }
+
+            this.LineColor = lineColor;
+        }
+
+        ///<inheritdoc/>
+        public override string ToZpl()
+        {
+            return $"{this.CommandPrefix}{this.CircleDiameter},{this.BorderThickness},{this.RenderLineColor(this.LineColor)}";
+        }
+
+        ///<inheritdoc/>
+        public override void ParseCommand(string zplCommand)
+        {
+            var zplDataParts = this.SplitCommand(zplCommand);
+
+            if (zplDataParts.Length > 0)
+            {
+                if (int.TryParse(zplDataParts[0], out var circleDiameter))
+                {
+                    this.CircleDiameter = circleDiameter;
+                }
+            }
+
+            if (zplDataParts.Length > 1)
+            {
+                if (int.TryParse(zplDataParts[1], out var borderThickness))
+                {
+                    this.BorderThickness = borderThickness;
+                }
+            }
+
+            if (zplDataParts.Length > 2)
+            {
+                var lineColorTemp = zplDataParts[2];
+                this.LineColor = lineColorTemp == "W" ? LineColor.White : LineColor.Black;
+            }
+        }
+    }
+}

--- a/src/BinaryKits.Zpl.Protocol/Commands/GraphicFieldCommand.cs
+++ b/src/BinaryKits.Zpl.Protocol/Commands/GraphicFieldCommand.cs
@@ -1,0 +1,120 @@
+﻿namespace BinaryKits.Zpl.Protocol.Commands
+{
+    /// <summary>
+    /// Graphic Field<br/>
+    /// The ^GF command allows you to download graphic field data directly into the printer’s bitmap storage area.
+    /// This command follows the conventions for any other field, meaning a field orientation is included.The
+    /// graphic field data can be placed at any location within the bitmap space.
+    /// </summary>
+    public class GraphicFieldCommand : CommandBase
+    {
+        /// <summary>
+        /// Compression type
+        /// </summary>
+        public char CompressionType { get; private set; } = 'A';
+
+        /// <summary>
+        /// Binary byte count
+        /// </summary>
+        public int BinaryByteCount { get; private set; }
+
+        /// <summary>
+        /// Graphic field count
+        /// </summary>
+        public int GraphicFieldCount { get; private set; }
+
+        /// <summary>
+        /// Bytes per row
+        /// </summary>
+        public int BytesPerRow { get; private set; }
+
+        /// <summary>
+        /// Data
+        /// </summary>
+        public string Data { get; private set; }
+
+        /// <summary>
+        /// Graphic Field
+        /// </summary>
+        public GraphicFieldCommand() : base("^GF")
+        { }
+
+        /// <summary>
+        /// Graphic Field
+        /// </summary>
+        /// <param name="compressionType">Compression type</param>
+        /// <param name="binaryByteCount">Binary byte count</param>
+        /// <param name="graphicFieldCount">Graphic field count</param>
+        /// <param name="bytesPerRow">Bytes per row</param>
+        /// <param name="data">Data</param>
+        public GraphicFieldCommand(
+            char compressionType = 'A',
+            int binaryByteCount = 1,
+            int graphicFieldCount = 1,
+            int bytesPerRow = 1,
+            string data = null)
+            : this()
+        {
+            this.CompressionType = compressionType;
+
+            if (this.ValidateIntParameter(nameof(binaryByteCount), binaryByteCount, 1, 99999))
+            {
+                this.BinaryByteCount = binaryByteCount;
+            }
+
+            if (this.ValidateIntParameter(nameof(graphicFieldCount), graphicFieldCount, 1, 99999))
+            {
+                this.GraphicFieldCount = graphicFieldCount;
+            }
+
+            if (this.ValidateIntParameter(nameof(bytesPerRow), bytesPerRow, 1, 99999))
+            {
+                this.BytesPerRow = bytesPerRow;
+            }
+
+            this.Data = data;
+        }
+
+        ///<inheritdoc/>
+        public override string ToZpl()
+        {
+            return $"{this.CommandPrefix}{this.CompressionType},{this.BinaryByteCount},{this.GraphicFieldCount},{this.BytesPerRow},{this.Data}";
+        }
+
+        ///<inheritdoc/>
+        public override void ParseCommand(string zplCommand)
+        {
+            var zplDataParts = this.SplitCommand(zplCommand);
+
+            if (zplDataParts.Length > 0)
+            {
+                this.CompressionType = zplDataParts[0][0];
+            }
+            if (zplDataParts.Length > 1)
+            {
+                if (int.TryParse(zplDataParts[1], out var binaryByteCount))
+                {
+                    this.BinaryByteCount = binaryByteCount;
+                }
+            }
+            if (zplDataParts.Length > 2)
+            {
+                if (int.TryParse(zplDataParts[2], out var graphicFieldCount))
+                {
+                    this.GraphicFieldCount = graphicFieldCount;
+                }
+            }
+            if (zplDataParts.Length > 3)
+            {
+                if (int.TryParse(zplDataParts[3], out var bytesPerRow))
+                {
+                    this.BytesPerRow = bytesPerRow;
+                }
+            }
+            if (zplDataParts.Length > 4)
+            {
+                this.Data = zplDataParts[4];
+            }
+        }
+    }
+}

--- a/src/BinaryKits.Zpl.Protocol/Commands/ImageMoveCommand.cs
+++ b/src/BinaryKits.Zpl.Protocol/Commands/ImageMoveCommand.cs
@@ -1,0 +1,62 @@
+﻿namespace BinaryKits.Zpl.Protocol.Commands
+{
+    /// <summary>
+    /// Image Move<br/>
+    /// The ^IM command performs a direct move of an image from storage area into the bitmap. The command is
+    /// identical to the ^XG command(Recall Graphic), except there are no sizing parameters.
+    /// </summary>
+    public class ImageMoveCommand : CommandBase
+    {
+        /// <summary>
+        /// Location of stored object
+        /// </summary>
+        public string LocationOfStoredObject { get; private set; }
+
+        /// <summary>
+        /// Image name
+        /// </summary>
+        public string ImageName { get; private set; } = "UNKNOWN.GRF";
+
+        /// <summary>
+        /// Image Move
+        /// </summary>
+        public ImageMoveCommand() : base("^IM")
+        { }
+
+        /// <summary>
+        /// Image Move
+        /// </summary>
+        /// <param name="locationOfStoredObject">Location of stored object</param>
+        /// <param name="imageName">Image name</param>
+        public ImageMoveCommand(
+            string locationOfStoredObject,
+            string imageName)
+            : this()
+        {
+            this.LocationOfStoredObject = locationOfStoredObject;
+            this.ImageName = imageName;
+        }
+
+        ///<inheritdoc/>
+        public override string ToZpl()
+        {
+            return $"{this.CommandPrefix}{this.LocationOfStoredObject}{this.ImageName}";
+        }
+
+        ///<inheritdoc/>
+        public override void ParseCommand(string zplCommand)
+        {
+            var zplData = zplCommand.Substring(this.CommandPrefix.Length);
+
+            if (zplData.Length >= 2)
+            {
+                this.LocationOfStoredObject = zplData.Substring(0, 2);
+            }
+
+            if (zplData.Length > 2)
+            {
+                this.ImageName = zplData.Substring(2);
+            }
+        }
+    }
+}

--- a/src/BinaryKits.Zpl.Protocol/Commands/ImageMoveCommand.cs
+++ b/src/BinaryKits.Zpl.Protocol/Commands/ImageMoveCommand.cs
@@ -8,9 +8,9 @@
     public class ImageMoveCommand : CommandBase
     {
         /// <summary>
-        /// Location of stored object
+        /// Storage device
         /// </summary>
-        public string LocationOfStoredObject { get; private set; }
+        public string StorageDevice { get; private set; } = "R:";
 
         /// <summary>
         /// Image name
@@ -26,21 +26,21 @@
         /// <summary>
         /// Image Move
         /// </summary>
-        /// <param name="locationOfStoredObject">Location of stored object</param>
+        /// <param name="storageDevice">Storage device</param>
         /// <param name="imageName">Image name</param>
         public ImageMoveCommand(
-            string locationOfStoredObject,
+            string storageDevice,
             string imageName)
             : this()
         {
-            this.LocationOfStoredObject = locationOfStoredObject;
+            this.StorageDevice = storageDevice;
             this.ImageName = imageName;
         }
 
         ///<inheritdoc/>
         public override string ToZpl()
         {
-            return $"{this.CommandPrefix}{this.LocationOfStoredObject}{this.ImageName}";
+            return $"{this.CommandPrefix}{this.StorageDevice}{this.ImageName}";
         }
 
         ///<inheritdoc/>
@@ -50,7 +50,7 @@
 
             if (zplData.Length >= 2)
             {
-                this.LocationOfStoredObject = zplData.Substring(0, 2);
+                this.StorageDevice = zplData.Substring(0, 2);
             }
 
             if (zplData.Length > 2)

--- a/src/BinaryKits.Zpl.Protocol/Commands/Interleaved2Of5BarCodeCommand.cs
+++ b/src/BinaryKits.Zpl.Protocol/Commands/Interleaved2Of5BarCodeCommand.cs
@@ -1,0 +1,112 @@
+﻿namespace BinaryKits.Zpl.Protocol.Commands
+{
+    /// <summary>
+    /// Interleaved 2 of 5 Bar Code<br/>
+    /// The ^B2 command produces the Interleaved 2 of 5 bar code, a high-density, self-checking, continuous,
+    /// numeric symbology.
+    /// Each data character for the Interleaved 2 of 5 bar code is composed of five elements: five bars or five
+    /// spaces.Of the five elements, two are wide and three are narrow.The bar code is formed by interleaving
+    /// characters formed with all spaces into characters formed with all bars. 
+    /// </summary>
+    public class Interleaved2Of5BarCodeCommand : CommandBase
+    {
+        /// <summary>
+        /// Orientation
+        /// </summary>
+        public Orientation Orientation { get; private set; } = Orientation.Normal;
+
+        /// <summary>
+        /// Bar code height
+        /// </summary>
+        public int? BarCodeHeight { get; private set; }
+
+        /// <summary>
+        /// Print interpretation line
+        /// </summary>
+        public bool PrintInterpretationLine { get; private set; } = true;
+
+        /// <summary>
+        /// Print interpretation line above code
+        /// </summary>
+        public bool PrintInterpretationLineAboveCode { get; private set; } = false;
+
+        /// <summary>
+        /// Calculate and print Mod 10 check digit
+        /// </summary>
+        public bool CalculateAndPrintMod10CheckDigit { get; private set; } = false;
+
+        /// <summary>
+        /// Interleaved 2 of 5 Bar Code
+        /// </summary>
+        public Interleaved2Of5BarCodeCommand() : base("^B2")
+        { }
+
+        /// <summary>
+        /// Interleaved 2 of 5 Bar Code
+        /// </summary>
+        /// <param name="orientation">Orientation</param>
+        /// <param name="barCodeHeight">Bar code height (1 to 32000)</param>
+        /// <param name="printInterpretationLine">Print interpretation line</param>
+        /// <param name="printInterpretationLineAboveCode">Print interpretation line above code</param>
+        /// <param name="calculateAndPrintMod10CheckDigit">Calculate and print Mod 10 check digit</param>
+        public Interleaved2Of5BarCodeCommand(
+            Orientation orientation = Orientation.Normal,
+            int? barCodeHeight = null,
+            bool printInterpretationLine = true,
+            bool printInterpretationLineAboveCode = false,
+            bool calculateAndPrintMod10CheckDigit = false)
+            : this()
+        {
+            this.Orientation = orientation;
+
+            if (this.ValidateIntParameter(nameof(barCodeHeight), barCodeHeight, 1, 32000))
+            {
+                this.BarCodeHeight = barCodeHeight.Value;
+            }
+
+            this.PrintInterpretationLine = printInterpretationLine;
+            this.PrintInterpretationLineAboveCode = printInterpretationLineAboveCode;
+            this.CalculateAndPrintMod10CheckDigit = calculateAndPrintMod10CheckDigit;
+        }
+
+        ///<inheritdoc/>
+        public override string ToZpl()
+        {
+            return $"{this.CommandPrefix}{this.RenderOrientation(this.Orientation)},{this.BarCodeHeight},{this.RenderBoolean(this.PrintInterpretationLine)},{this.RenderBoolean(this.PrintInterpretationLineAboveCode)},{this.RenderBoolean(this.CalculateAndPrintMod10CheckDigit)}";
+        }
+
+        ///<inheritdoc/>
+        public override void ParseCommand(string zplCommand)
+        {
+            var zplDataParts = this.SplitCommand(zplCommand);
+
+            if (zplDataParts.Length > 0)
+            {
+                this.Orientation = this.ConvertOrientation(zplDataParts[0]);
+            }
+
+            if (zplDataParts.Length > 1)
+            {
+                if (int.TryParse(zplDataParts[1], out var barCodeHeight))
+                {
+                    this.BarCodeHeight = barCodeHeight;
+                }
+            }
+
+            if (zplDataParts.Length > 2)
+            {
+                this.PrintInterpretationLine = this.ConvertBoolean(zplDataParts[2]);
+            }
+
+            if (zplDataParts.Length > 3)
+            {
+                this.PrintInterpretationLineAboveCode = this.ConvertBoolean(zplDataParts[3]);
+            }
+
+            if (zplDataParts.Length > 4)
+            {
+                this.CalculateAndPrintMod10CheckDigit = this.ConvertBoolean(zplDataParts[4]);
+            }
+        }
+    }
+}

--- a/src/BinaryKits.Zpl.Protocol/Commands/LabelHomeCommand.cs
+++ b/src/BinaryKits.Zpl.Protocol/Commands/LabelHomeCommand.cs
@@ -1,0 +1,82 @@
+﻿namespace BinaryKits.Zpl.Protocol.Commands
+{
+    /// <summary>
+    /// Label Home<br/>
+    /// The ^LH command sets the label home position.
+    /// 
+    /// The default home position of a label is the upper-left corner (position 0,0 along the x and y axis). This is the
+    /// axis reference point for labels. Any area below and to the right of this point is available for printing. The ^LH
+    /// command changes this reference point. For instance, when working with preprinted labels, use this
+    /// command to move the reference point below the preprinted area.
+    /// 
+    /// This command affects only fields that come after it. It is recommended to use ^LH as one of the first
+    /// commands in the label format.
+    /// </summary>
+    public class LabelHomeCommand : CommandBase
+    {
+        /// <summary>
+        /// X-axis position
+        /// </summary>
+        public int X { get; private set; } = 0;
+
+        /// <summary>
+        /// Y-axis position
+        /// </summary>
+        public int Y { get; private set; } = 0;
+
+        /// <summary>
+        /// Field Origin
+        /// </summary>
+        public LabelHomeCommand() : base("^LH")
+        { }
+
+        /// <summary>
+        /// Field Origin
+        /// </summary>
+        /// <param name="x">x-axis position (0 to 32000)</param>
+        /// <param name="y">y-axis position (0 to 32000)</param>
+        public LabelHomeCommand(
+            int? x = null,
+            int? y = null)
+            : this()
+        {
+            if (this.ValidateIntParameter(nameof(x), x, 0, 32000))
+            {
+                this.X = x.Value;
+            }
+
+            if (this.ValidateIntParameter(nameof(y), y, 0, 32000))
+            {
+                this.Y = y.Value;
+            }
+        }
+
+        ///<inheritdoc/>
+        public override string ToZpl()
+        {
+            return $"{this.CommandPrefix}{this.X},{this.Y}";
+        }
+
+        ///<inheritdoc/>
+        public override void ParseCommand(string zplCommand)
+        {
+            var zplDataParts = this.SplitCommand(zplCommand);
+
+            if (zplDataParts.Length > 0)
+            {
+                if (int.TryParse(zplDataParts[0], out var x))
+                {
+                    this.X = x;
+                }
+            }
+
+            if (zplDataParts.Length > 1)
+            {
+                if (int.TryParse(zplDataParts[1], out var y))
+                {
+                    this.Y = y;
+                }
+            }
+        }
+    }
+}

--- a/src/BinaryKits.Zpl.Protocol/Commands/LabelHomeCommand.cs
+++ b/src/BinaryKits.Zpl.Protocol/Commands/LabelHomeCommand.cs
@@ -25,13 +25,13 @@
         public int Y { get; private set; } = 0;
 
         /// <summary>
-        /// Field Origin
+        /// Label Home
         /// </summary>
         public LabelHomeCommand() : base("^LH")
         { }
 
         /// <summary>
-        /// Field Origin
+        /// Label Home
         /// </summary>
         /// <param name="x">x-axis position (0 to 32000)</param>
         /// <param name="y">y-axis position (0 to 32000)</param>

--- a/src/BinaryKits.Zpl.Protocol/Commands/QrCodeBarCodeCommand.cs
+++ b/src/BinaryKits.Zpl.Protocol/Commands/QrCodeBarCodeCommand.cs
@@ -34,7 +34,9 @@
         public ErrorCorrectionLevel ErrorCorrection { get; private set; } = ErrorCorrectionLevel.HighReliability;
 
         /// <summary>
-        /// Mask value
+        /// Mask value<br/>
+        /// Before QR code is finally generated, the data bits must be XOR-ed with mask pattern.
+        /// This process have a purpose of making QR code more readable by QR scanner.
         /// </summary>
         public int MaskValue { get; private set; } = 7;
 

--- a/src/BinaryKits.Zpl.Protocol/Commands/QrCodeBarCodeCommand.cs
+++ b/src/BinaryKits.Zpl.Protocol/Commands/QrCodeBarCodeCommand.cs
@@ -1,0 +1,129 @@
+﻿namespace BinaryKits.Zpl.Protocol.Commands
+{
+    /// <summary>
+    /// QR Code Bar Code<br/>
+    /// The ^BQ command produces a matrix symbology consisting of an array of nominally square modules
+    /// arranged in an overall square pattern.A unique pattern at three of the symbol’s four corners assists in
+    /// determining bar code size, position, and inclination.
+    /// A wide range of symbol sizes is possible, along with four levels of error correction.User-specified module
+    /// dimensions provide a wide variety of symbol production techniques.
+    /// QR Code Model 1 is the original specification, while QR Code Model 2 is an enhanced form of the
+    /// symbology. Model 2 provides additional features and can be automatically differentiated from Model 1.
+    /// Model 2 is the recommended model and should normally be used.
+    /// </summary>
+    public class QrCodeBarCodeCommand : CommandBase
+    {
+        /// <summary>
+        /// Orientation
+        /// </summary>
+        public Orientation Orientation { get; private set; } = Orientation.Normal;
+
+        /// <summary>
+        /// Model
+        /// </summary>
+        public int Model { get; private set; } = 2;
+
+        /// <summary>
+        /// Magnification factor
+        /// </summary>
+        public int MagnificationFactor { get; private set; } = 1;
+
+        /// <summary>
+        /// Error correction
+        /// </summary>
+        public ErrorCorrectionLevel ErrorCorrection { get; private set; } = ErrorCorrectionLevel.HighReliability;
+
+        /// <summary>
+        /// Mask value
+        /// </summary>
+        public int MaskValue { get; private set; } = 7;
+
+        /// <summary>
+        /// QR Code Bar Code
+        /// </summary>
+        public QrCodeBarCodeCommand() : base("^BQ")
+        { }
+
+        /// <summary>
+        /// QR Code Bar Code
+        /// </summary>
+        /// <param name="orientation">Orientation</param>
+        /// <param name="model">Model 1 (original) and 2 (enhanced – recommended)</param>
+        /// <param name="magnificationFactor">Magnification factor</param>
+        /// <param name="errorCorrection">Error correction</param>
+        /// <param name="maskValue">Mask value</param>
+        public QrCodeBarCodeCommand(
+            Orientation orientation = Orientation.Normal,
+            int model = 2,
+            int magnificationFactor = 1,
+            ErrorCorrectionLevel errorCorrection = ErrorCorrectionLevel.HighReliability,
+            int maskValue = 7)
+            : this()
+        {
+            this.Orientation = orientation;
+
+            if (this.ValidateIntParameter(nameof(model), model, 1, 2))
+            {
+                this.Model = model;
+            }
+
+            if (this.ValidateIntParameter(nameof(magnificationFactor), magnificationFactor, 1, 10))
+            {
+                this.MagnificationFactor = magnificationFactor;
+            }
+
+            this.ErrorCorrection = errorCorrection;
+
+            if (this.ValidateIntParameter(nameof(maskValue), maskValue, 0, 7))
+            {
+                this.MaskValue = maskValue;
+            }
+        }
+
+        ///<inheritdoc/>
+        public override string ToZpl()
+        {
+            return $"{this.CommandPrefix}{this.RenderOrientation(this.Orientation)},{this.Model},{this.MagnificationFactor},{this.RenderErrorCorrectionLevel(this.ErrorCorrection)},{this.MaskValue}";
+        }
+
+        ///<inheritdoc/>
+        public override void ParseCommand(string zplCommand)
+        {
+            var zplDataParts = this.SplitCommand(zplCommand);
+
+            if (zplDataParts.Length > 0)
+            {
+                this.Orientation = this.ConvertOrientation(zplDataParts[0]);
+            }
+
+            if (zplDataParts.Length > 1)
+            {
+                if (int.TryParse(zplDataParts[1], out var model))
+                {
+                    this.Model = model;
+                }
+            }
+
+            if (zplDataParts.Length > 2)
+            {
+                if (int.TryParse(zplDataParts[2], out var magnificationFactor))
+                {
+                    this.MagnificationFactor = magnificationFactor;
+                }
+            }
+
+            if (zplDataParts.Length > 3)
+            {
+                this.ErrorCorrection = this.ConvertErrorCorrectionLevel(zplDataParts[3]);
+            }
+
+            if (zplDataParts.Length > 4)
+            {
+                if (int.TryParse(zplDataParts[4], out var maskValue))
+                {
+                    this.MaskValue = maskValue;
+                }
+            }
+        }
+    }
+}

--- a/src/BinaryKits.Zpl.Protocol/Commands/RecallGraphicCommand.cs
+++ b/src/BinaryKits.Zpl.Protocol/Commands/RecallGraphicCommand.cs
@@ -1,0 +1,109 @@
+﻿namespace BinaryKits.Zpl.Protocol.Commands
+{
+    /// <summary>
+    /// Recall Graphic<br/>
+    /// The ^XG command is used to recall one or more graphic images for printing. This command is
+    /// used in a label format to merge graphics, such as company logos and piece parts, with text data to form a
+    /// complete label.
+    /// </summary>
+    public class RecallGraphicCommand : CommandBase
+    {
+        /// <summary>
+        /// Storage device
+        /// </summary>
+        public string StorageDevice { get; private set; } = "R:";
+
+        /// <summary>
+        /// Image name
+        /// </summary>
+        public string ImageName { get; private set; } = "UNKNOWN.GRF";
+
+        /// <summary>
+        /// Magnification factor on the x-axis
+        /// </summary>
+        public int MagnificationFactorX { get; private set; } = 1;
+
+        /// <summary>
+        /// Magnification factor on the y-axis
+        /// </summary>
+        public int MagnificationFactorY { get; private set; } = 1;
+
+        /// <summary>
+        /// Recall Graphic
+        /// </summary>
+        public RecallGraphicCommand() : base("^XG")
+        { }
+
+        /// <summary>
+        /// Recall Graphic
+        /// </summary>
+        /// <param name="storageDevice">Storage device</param>
+        /// <param name="imageName">Image name</param>
+        /// <param name="magnificationFactorX">Magnification factor on the x-axis (1 to 10)</param>
+        /// <param name="magnificationFactorY">Magnification factor on the y-axis (1 to 10)</param>
+        public RecallGraphicCommand(
+            string storageDevice,
+            string imageName,
+            int magnificationFactorX = 1,
+            int magnificationFactorY = 1)
+            : this()
+        {
+            this.StorageDevice = storageDevice;
+            this.ImageName = imageName;
+
+            if (this.ValidateIntParameter(nameof(magnificationFactorX), magnificationFactorX, 1, 10))
+            {
+                this.MagnificationFactorX = magnificationFactorX;
+            }
+
+            if (this.ValidateIntParameter(nameof(magnificationFactorY), magnificationFactorY, 1, 10))
+            {
+                this.MagnificationFactorY = magnificationFactorY;
+            }
+        }
+
+        ///<inheritdoc/>
+        public override string ToZpl()
+        {
+            return $"{this.CommandPrefix}{this.StorageDevice}{this.ImageName},{this.MagnificationFactorX},{this.MagnificationFactorY}";
+        }
+
+        ///<inheritdoc/>
+        public override void ParseCommand(string zplCommand)
+        {
+            var zplData = zplCommand.Substring(this.CommandPrefix.Length);
+
+            if (zplData.Length >= 2)
+            {
+                this.StorageDevice = zplData.Substring(0, 2);
+            }
+
+            var zplDataParts = this.SplitCommand(zplCommand, 2);
+
+            if (zplDataParts.Length > 0)
+            {
+                var imageName = zplDataParts[0];
+                if (!string.IsNullOrEmpty(imageName))
+                {
+                    this.ImageName = imageName;
+                }
+            }
+
+            if (zplDataParts.Length > 1)
+            {
+                if (int.TryParse(zplDataParts[1], out var magnificationFactorY))
+                {
+                    this.MagnificationFactorX = magnificationFactorY;
+                }
+            }
+
+            if (zplDataParts.Length > 2)
+            {
+                if (int.TryParse(zplDataParts[2], out var magnificationFactorX))
+                {
+                    this.MagnificationFactorY = magnificationFactorX;
+                }
+            }
+        }
+    }
+}

--- a/src/BinaryKits.Zpl.Protocol/Commands/ScalableBitmappedFontCommand.cs
+++ b/src/BinaryKits.Zpl.Protocol/Commands/ScalableBitmappedFontCommand.cs
@@ -1,0 +1,100 @@
+﻿namespace BinaryKits.Zpl.Protocol.Commands
+{
+    /// <summary>
+    /// Scalable/Bitmapped Font<br/>
+    /// The ^A command specifies the font to use in a text field. ^A designates the font for the current ^FD
+    /// statement or field.The font specified by ^A is used only once for that ^FD entry.If a value for ^A is not
+    /// specified again, the default ^CF font is used for the next ^FD entry.
+    /// </summary>
+    public class ScalableBitmappedFontCommand : CommandBase
+    {
+        /// <summary>
+        /// Font name
+        /// </summary>
+        public char FontName { get; private set; }
+
+        /// <summary>
+        /// Field orientation
+        /// </summary>
+        public FieldOrientation FieldOrientation { get; private set; }
+
+        /// <summary>
+        /// Character Height
+        /// </summary>
+        public int? CharacterHeight { get; private set; }
+
+        /// <summary>
+        /// Width
+        /// </summary>
+        public int? Width { get; private set; }
+
+        /// <summary>
+        /// Scalable/Bitmapped Font
+        /// </summary>
+        public ScalableBitmappedFontCommand() : base("^A")
+        { }
+
+        /// <summary>
+        /// Scalable/Bitmapped Font
+        /// </summary>
+        /// <param name="fontName">Font name, A through Z, and 0 to 9</param>
+        /// <param name="fieldOrientation">Field orientation</param>
+        /// <param name="characterHeight">Character Height (10 to 32000)</param>
+        /// <param name="width">width (10 to 32000)</param>
+        public ScalableBitmappedFontCommand(
+            char fontName,
+            FieldOrientation fieldOrientation = FieldOrientation.Normal,
+            int? characterHeight = 10,
+            int? width = 10)
+            : this()
+        {
+            this.FontName = fontName;
+            this.FieldOrientation = fieldOrientation;
+
+            if (this.ValidateIntParameter(nameof(characterHeight), characterHeight, 10, 32000))
+            {
+                this.CharacterHeight = characterHeight.Value;
+            }
+
+            if (this.ValidateIntParameter(nameof(width), width, 10, 32000))
+            {
+                this.Width = width.Value;
+            }
+        }
+
+        ///<inheritdoc/>
+        public override string ToZpl()
+        {
+            return $"{this.CommandPrefix}{this.FontName}{this.RenderFieldOrientation(this.FieldOrientation)},{this.CharacterHeight},{this.Width}";
+        }
+
+        ///<inheritdoc/>
+        public override void ParseCommand(string zplCommand)
+        {
+            this.FontName = zplCommand[this.CommandPrefix.Length];
+
+            var zplDataParts = this.SplitCommand(zplCommand, 1);
+
+            if (zplDataParts.Length > 0)
+            {
+                this.FieldOrientation = this.ConvertFieldOrientation(zplDataParts[0]);
+            }
+
+            if (zplDataParts.Length > 1)
+            {
+                if (int.TryParse(zplDataParts[1], out var characterHeight))
+                {
+                    this.CharacterHeight = characterHeight;
+                }
+            }
+
+            if (zplDataParts.Length > 2)
+            {
+                if (int.TryParse(zplDataParts[2], out var width))
+                {
+                    this.Width = width;
+                }
+            }
+        }
+    }
+}

--- a/src/BinaryKits.Zpl.Protocol/Commands/ScalableBitmappedFontCommand.cs
+++ b/src/BinaryKits.Zpl.Protocol/Commands/ScalableBitmappedFontCommand.cs
@@ -14,9 +14,9 @@
         public char FontName { get; private set; }
 
         /// <summary>
-        /// Field orientation
+        /// Orientation
         /// </summary>
-        public FieldOrientation FieldOrientation { get; private set; }
+        public Orientation Orientation { get; private set; }
 
         /// <summary>
         /// Character Height
@@ -38,18 +38,18 @@
         /// Scalable/Bitmapped Font
         /// </summary>
         /// <param name="fontName">Font name, A through Z, and 0 to 9</param>
-        /// <param name="fieldOrientation">Field orientation</param>
+        /// <param name="orientation">Orientation</param>
         /// <param name="characterHeight">Character Height (10 to 32000)</param>
         /// <param name="width">width (10 to 32000)</param>
         public ScalableBitmappedFontCommand(
             char fontName,
-            FieldOrientation fieldOrientation = FieldOrientation.Normal,
+            Orientation orientation = Orientation.Normal,
             int? characterHeight = 10,
             int? width = 10)
             : this()
         {
             this.FontName = fontName;
-            this.FieldOrientation = fieldOrientation;
+            this.Orientation = orientation;
 
             if (this.ValidateIntParameter(nameof(characterHeight), characterHeight, 10, 32000))
             {
@@ -65,7 +65,7 @@
         ///<inheritdoc/>
         public override string ToZpl()
         {
-            return $"{this.CommandPrefix}{this.FontName}{this.RenderFieldOrientation(this.FieldOrientation)},{this.CharacterHeight},{this.Width}";
+            return $"{this.CommandPrefix}{this.FontName}{this.RenderOrientation(this.Orientation)},{this.CharacterHeight},{this.Width}";
         }
 
         ///<inheritdoc/>
@@ -77,7 +77,7 @@
 
             if (zplDataParts.Length > 0)
             {
-                this.FieldOrientation = this.ConvertFieldOrientation(zplDataParts[0]);
+                this.Orientation = this.ConvertOrientation(zplDataParts[0]);
             }
 
             if (zplDataParts.Length > 1)

--- a/src/BinaryKits.Zpl.Protocol/ErrorCorrectionLevel.cs
+++ b/src/BinaryKits.Zpl.Protocol/ErrorCorrectionLevel.cs
@@ -1,0 +1,25 @@
+﻿namespace BinaryKits.Zpl.Protocol
+{
+    /// <summary>
+    /// QR-Code - Error Correction Level 
+    /// </summary>
+    public enum ErrorCorrectionLevel
+    {
+        /// <summary>
+        /// Ultra-high reliability level
+        /// </summary>
+        UltraHighReliability,
+        /// <summary>
+        /// High reliability level
+        /// </summary>
+        HighReliability,
+        /// <summary>
+        /// Standard level
+        /// </summary>
+        Standard,
+        /// <summary>
+        /// High density
+        /// </summary>
+        HighDensity
+    }
+}

--- a/src/BinaryKits.Zpl.Protocol/FieldOrientation.cs
+++ b/src/BinaryKits.Zpl.Protocol/FieldOrientation.cs
@@ -1,0 +1,25 @@
+﻿namespace BinaryKits.Zpl.Protocol
+{
+    /// <summary>
+    /// Field Orientation
+    /// </summary>
+    public enum FieldOrientation
+    {
+        /// <summary>
+        /// Normal
+        /// </summary>
+        Normal,
+        /// <summary>
+        /// Rotated 90 degrees (clockwise)
+        /// </summary>
+        Rotated90,
+        /// <summary>
+        /// Inverted 180 degrees
+        /// </summary>
+        Rotated180,
+        /// <summary>
+        /// Read from bottom up, 270 degrees
+        /// </summary>
+        Rotated270
+    }
+}

--- a/src/BinaryKits.Zpl.Protocol/GraphicSymbolCharacter.cs
+++ b/src/BinaryKits.Zpl.Protocol/GraphicSymbolCharacter.cs
@@ -1,0 +1,29 @@
+﻿namespace BinaryKits.Zpl.Protocol
+{
+    /// <summary>
+    /// Graphic Symbol Character
+    /// </summary>
+    public enum GraphicSymbolCharacter
+    {
+        /// <summary>
+        /// Registered Trade Mark
+        /// </summary>
+        RegisteredTradeMark,
+        /// <summary>
+        /// Copyright
+        /// </summary>
+        Copyright,
+        /// <summary>
+        /// Trade Mark
+        /// </summary>
+        TradeMark,
+        /// <summary>
+        /// Underwriters Laboratories Approval
+        /// </summary>
+        UnderwritersLaboratoriesApproval,
+        /// <summary>
+        /// Canadian Standards Association Approval
+        /// </summary>
+        CanadianStandardsAssociationApproval
+    }
+}

--- a/src/BinaryKits.Zpl.Protocol/Helpers/ZebraHexCompressionHelper.cs
+++ b/src/BinaryKits.Zpl.Protocol/Helpers/ZebraHexCompressionHelper.cs
@@ -1,0 +1,233 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace BinaryKits.Zpl.Protocol.Helpers
+{
+    /// <summary>
+    /// Alternative Data Compression Scheme for ~DG and ~DB Commands
+    /// There is an alternative data compression scheme recognized by the Zebra printer. This scheme further
+    /// reduces the actual number of data bytes and the amount of time required to download graphic images and
+    /// bitmapped fonts with the ~DG and ~DB commands
+    /// </summary>
+    public static class ZebraHexCompressionHelper
+    {
+        /// <summary>
+        /// MinCompressionBlockCount (CompressionCountMapping -> g)
+        /// </summary>
+        const int MinCompressionBlockCount = 20;
+
+        /// <summary>
+        /// CompressionCountMapping (CompressionCountMapping -> z)
+        /// </summary>
+        const int MaxCompressionRepeatCount = 400;
+
+        /// <summary>
+        /// The mapping table used for compression.
+        /// Each character count (the key) is represented by a certain char (the value).
+        /// </summary>
+        private static readonly Dictionary<int, char> CompressionCountMapping = new Dictionary<int, char>()
+        {
+            {1, 'G'}, {2, 'H'}, {3, 'I'}, {4, 'J'}, {5, 'K'}, {6, 'L'}, {7, 'M'}, {8, 'N'}, {9, 'O' }, {10, 'P'},
+            {11, 'Q'}, {12, 'R'}, {13, 'S'}, {14, 'T'}, {15, 'U'}, {16, 'V'}, {17, 'W'}, {18, 'X'}, {19, 'Y'},
+            {20, 'g'}, {40, 'h'}, {60, 'i'}, {80, 'j' }, {100, 'k'}, {120, 'l'}, {140, 'm'}, {160, 'n'}, {180, 'o'}, {200, 'p'},
+            {220, 'q'}, {240, 'r'}, {260, 's'}, {280, 't'}, {300, 'u'}, {320, 'v'}, {340, 'w'}, {360, 'x'}, {380, 'y'}, {400, 'z' }
+        };
+
+        private static IEnumerable<string> Split(string str, int chunkSize)
+        {
+            return Enumerable.Range(0, str.Length / chunkSize).Select(i => str.Substring(i * chunkSize, chunkSize));
+        }
+
+        /// <summary>
+        /// Compress hex
+        /// </summary>
+        /// <param name="hexData">Clean hex data 000000\nFFFFFF</param>
+        /// <param name="bytesPerRow"></param>
+        /// <returns></returns>
+        public static string Compress(string hexData, int bytesPerRow)
+        {
+            var chunkSize = bytesPerRow * 2;
+            var cleanedHexData = hexData.Replace("\n", string.Empty).Replace("\r", string.Empty);
+
+            var compressedLines = new StringBuilder(hexData.Length);
+            var compressedCurrentLine = new StringBuilder(chunkSize);
+            var compressedPreviousLine = string.Empty;
+
+            var dataLines = Split(cleanedHexData, chunkSize);
+            foreach (var dataLine in dataLines)
+            {
+                var lastChar = dataLine[0];
+                var charRepeatCount = 1;
+
+                for (var i = 1; i < dataLine.Length; i++)
+                {
+                    if (dataLine[i] == lastChar)
+                    {
+                        charRepeatCount++;
+                        continue;
+                    }
+
+                    //char changed within the line
+                    compressedCurrentLine.Append(GetZebraCharCount(charRepeatCount));
+                    compressedCurrentLine.Append(lastChar);
+
+                    lastChar = dataLine[i];
+                    charRepeatCount = 1;
+                }
+
+                //process last char in dataLine
+                if (lastChar.Equals('0'))
+                {
+                    //fills the line, to the right, with zeros
+                    compressedCurrentLine.Append(',');
+                }
+                else if (lastChar.Equals('1'))
+                {
+                    //fills the line, to the right, with ones
+                    compressedCurrentLine.Append('!');
+                }
+                else
+                {
+                    compressedCurrentLine.Append(GetZebraCharCount(charRepeatCount));
+                    compressedCurrentLine.Append(lastChar);
+                }
+
+                if (compressedCurrentLine.Equals(compressedPreviousLine))
+                {
+                    //previous line is repeated
+                    compressedLines.Append(':');
+                }
+                else
+                {
+                    compressedLines.Append(compressedCurrentLine);
+                }
+
+                compressedPreviousLine = compressedCurrentLine.ToString();
+                compressedCurrentLine.Clear();
+            }
+
+            return compressedLines.ToString();
+        }
+
+        /// <summary>
+        /// Uncompress data
+        /// </summary>
+        /// <param name="compressedHexData"></param>
+        /// <param name="bytesPerRow"></param>
+        /// <returns></returns>
+        public static string Uncompress(string compressedHexData, int bytesPerRow)
+        {
+            var hexData = new StringBuilder();
+            var chunkSize = bytesPerRow * 2;
+            var lineIndex = 0;
+            var totalCount = 0;
+
+            var reverseMapping = CompressionCountMapping.ToDictionary(o => o.Value, o => o.Key);
+
+            foreach (var c in compressedHexData)
+            {
+                if (c.Equals(':'))
+                {
+                    var appendRepeat = hexData.ToString().Substring(hexData.Length - (chunkSize + 1));
+                    hexData.Append(appendRepeat);
+                    continue;
+                }
+
+                if (c.Equals(','))
+                {
+                    var appendZero = new string('0', chunkSize - lineIndex);
+                    hexData.Append(appendZero);
+                    hexData.Append("\n");
+                    lineIndex = 0;
+                    continue;
+                }
+
+                if (c.Equals('!'))
+                {
+                    var appendOne = new string('1', chunkSize - lineIndex);
+                    hexData.Append(appendOne);
+                    hexData.Append("\n");
+                    lineIndex = 0;
+                    continue;
+                }
+
+                if (reverseMapping.TryGetValue(c, out var count))
+                {
+                    totalCount += count;
+                    continue;
+                }
+
+                if (totalCount == 0)
+                {
+                    totalCount = 1;
+                }
+
+                var append = new string(c, totalCount);
+                hexData.Append(append);
+                lineIndex += append.Length;
+                totalCount = 0;
+
+                if (lineIndex == chunkSize)
+                {
+                    hexData.Append("\n");
+                    lineIndex = 0;
+                }
+            }
+
+            return hexData.ToString();
+        }
+
+        /// <summary>
+        /// Get Zebra char repeat count
+        /// </summary>
+        /// <param name="charRepeatCount"></param>
+        /// <returns></returns>
+        public static string GetZebraCharCount(int charRepeatCount)
+        {
+            if (CompressionCountMapping.TryGetValue(charRepeatCount, out var compressionKey))
+            {
+                return $"{compressionKey}";
+            }
+
+            var compressionKeys = new StringBuilder(5);
+
+            var multi20 = charRepeatCount / MinCompressionBlockCount * MinCompressionBlockCount;
+            var remainder = charRepeatCount % multi20;
+
+            while (remainder > 0 || multi20 > 0)
+            {
+                if (multi20 > MaxCompressionRepeatCount)
+                {
+                    remainder += multi20 - MaxCompressionRepeatCount;
+                    multi20 = MaxCompressionRepeatCount;
+                }
+
+                if (!CompressionCountMapping.TryGetValue(multi20, out compressionKey))
+                {
+                    throw new Exception("Compression failure");
+                }
+
+                compressionKeys.Append(compressionKey);
+
+                if (remainder == 0)
+                {
+                    break;
+                }
+
+                if (remainder <= 20)
+                {
+                    CompressionCountMapping.TryGetValue(remainder, out compressionKey);
+                    compressionKeys.Append(compressionKey);
+                    break;
+                }
+
+                multi20 = remainder / MinCompressionBlockCount * MinCompressionBlockCount;
+                remainder %= multi20;
+            }
+
+            return compressionKeys.ToString();
+        }
+    }
+}

--- a/src/BinaryKits.Zpl.Protocol/ImageConverters/IImageConverter.cs
+++ b/src/BinaryKits.Zpl.Protocol/ImageConverters/IImageConverter.cs
@@ -1,0 +1,23 @@
+﻿namespace BinaryKits.Zpl.Protocol.ImageConverters
+{
+    /// <summary>
+    /// Image Converter
+    /// </summary>
+    public interface IImageConverter
+    {
+        /// <summary>
+        /// Convert image to bitonal image (grf)
+        /// </summary>
+        /// <param name="imageData"></param>
+        /// <returns></returns>
+        ImageResult ConvertImage(byte[] imageData);
+
+        /// <summary>
+        /// Convert from bitonal image (grf) to png image
+        /// </summary>
+        /// <param name="imageData"></param>
+        /// <param name="bytesPerRow"></param>
+        /// <returns></returns>
+        byte[] ConvertImage(byte[] imageData, int bytesPerRow);
+    }
+}

--- a/src/BinaryKits.Zpl.Protocol/ImageConverters/ImageResult.cs
+++ b/src/BinaryKits.Zpl.Protocol/ImageConverters/ImageResult.cs
@@ -1,0 +1,21 @@
+﻿namespace BinaryKits.Zpl.Protocol.ImageConverters
+{
+    /// <summary>
+    /// Zebra Image Result
+    /// </summary>
+    public class ImageResult
+    {
+        /// <summary>
+        /// Zpl Image Data
+        /// </summary>
+        public string ZplData { get; set; }
+        /// <summary>
+        /// Binary byte count
+        /// </summary>
+        public int BinaryByteCount { get; set; }
+        /// <summary>
+        /// Bytes per row
+        /// </summary>
+        public int BytesPerRow { get; set; }
+    }
+}

--- a/src/BinaryKits.Zpl.Protocol/ImageConverters/ImageSharpImageConverter.cs
+++ b/src/BinaryKits.Zpl.Protocol/ImageConverters/ImageSharpImageConverter.cs
@@ -1,0 +1,111 @@
+﻿using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+using System.Collections;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace BinaryKits.Zpl.Protocol.ImageConverters
+{
+    /// <summary>
+    /// ImageSharp Image Converter
+    /// </summary>
+    public class ImageSharpImageConverter : IImageConverter
+    {
+        ///<inheritdoc/>
+        public ImageResult ConvertImage(byte[] imageData)
+        {
+            var zplBuilder = new StringBuilder();
+
+            using (Image<Rgba32> image = Image.Load(imageData))
+            {
+                var bytesPerRow = image.Width % 8 > 0
+                    ? image.Width / 8 + 1
+                    : image.Width / 8;
+
+                var binaryByteCount = image.Height * bytesPerRow;
+
+                var colorBits = 0;
+                var j = 0;
+
+                for (var y = 0; y < image.Height; y++)
+                {
+                    var row = image.GetPixelRowSpan(y);
+
+                    for (var x = 0; x < image.Width; x++)
+                    {
+                        var pixel = row[x];
+
+                        var isBlackPixel = ((pixel.R + pixel.G + pixel.B) / 3) < 128;
+                        if (isBlackPixel)
+                        {
+                            colorBits |= 1 << (7 - j);
+                        }
+
+                        j++;
+
+                        if (j == 8 || x == (image.Width - 1))
+                        {
+                            zplBuilder.Append(colorBits.ToString("X2"));
+                            colorBits = 0;
+                            j = 0;
+                        }
+                    }
+                    zplBuilder.Append('\n');
+                }
+
+                return new ImageResult
+                {
+                    ZplData = zplBuilder.ToString(),
+                    BinaryByteCount = binaryByteCount,
+                    BytesPerRow = bytesPerRow
+                };
+            }
+        }
+
+        private byte Reverse(byte b)
+        {
+            var reverse = 0;
+            for (var i = 0; i < 8; i++)
+            {
+                if ((b & (1 << i)) != 0)
+                {
+                    reverse |= 1 << (7 - i);
+                }
+            }
+            return (byte)reverse;
+        }
+
+        ///<inheritdoc/>
+        public byte[] ConvertImage(byte[] imageData, int bytesPerRow)
+        {
+            imageData = imageData.Select(b => Reverse(b)).ToArray();
+
+            var imageHeight = imageData.Length / bytesPerRow;
+            var imageWidth = bytesPerRow * 8;
+
+            using (var image = new Image<Rgba32>(imageWidth, imageHeight))
+            {
+                for (var y = 0; y < image.Height; y++)
+                {
+                    var row = image.GetPixelRowSpan(y);
+                    var bits = new BitArray(imageData.Skip(bytesPerRow * y).Take(bytesPerRow).ToArray());
+
+                    for (var x = 0 ; x < image.Width; x++)
+                    {
+                        if (bits[x])
+                        {
+                            row[x].A = 255;
+                        }
+                    }
+                }
+
+                using (var memoryStream = new MemoryStream())
+                {
+                    image.SaveAsPng(memoryStream);
+                    return memoryStream.ToArray();
+                }
+            }
+        }
+    }
+}

--- a/src/BinaryKits.Zpl.Protocol/LineColor.cs
+++ b/src/BinaryKits.Zpl.Protocol/LineColor.cs
@@ -1,0 +1,17 @@
+﻿namespace BinaryKits.Zpl.Protocol
+{
+    /// <summary>
+    /// Line Color
+    /// </summary>
+    public enum LineColor
+    {
+        /// <summary>
+        /// Black
+        /// </summary>
+        Black,
+        /// <summary>
+        /// White
+        /// </summary>
+        White
+    }
+}

--- a/src/BinaryKits.Zpl.Protocol/NewLineConversionMethod.cs
+++ b/src/BinaryKits.Zpl.Protocol/NewLineConversionMethod.cs
@@ -1,0 +1,21 @@
+﻿namespace BinaryKits.Zpl.Protocol
+{
+    /// <summary>
+    /// NewLine Conversion Method
+    /// </summary>
+    public enum NewLineConversionMethod
+    {
+        /// <summary>
+        /// To Space
+        /// </summary>
+        ToSpace,
+        /// <summary>
+        /// To Empty
+        /// </summary>
+        ToEmpty,
+        /// <summary>
+        /// To Zpl NewLine
+        /// </summary>
+        ToZplNewLine,
+    }
+}

--- a/src/BinaryKits.Zpl.Protocol/Orientation.cs
+++ b/src/BinaryKits.Zpl.Protocol/Orientation.cs
@@ -1,9 +1,9 @@
 ﻿namespace BinaryKits.Zpl.Protocol
 {
     /// <summary>
-    /// Field Orientation
+    /// Orientation
     /// </summary>
-    public enum FieldOrientation
+    public enum Orientation
     {
         /// <summary>
         /// Normal

--- a/src/BinaryKits.Zpl.Protocol/TextJustification.cs
+++ b/src/BinaryKits.Zpl.Protocol/TextJustification.cs
@@ -1,0 +1,25 @@
+﻿namespace BinaryKits.Zpl.Protocol
+{
+    /// <summary>
+    /// Text Justification
+    /// </summary>
+    public enum TextJustification
+    {
+        /// <summary>
+        /// Left
+        /// </summary>
+        Left,
+        /// <summary>
+        /// Center
+        /// </summary>
+        Center,
+        /// <summary>
+        /// Right
+        /// </summary>
+        Right,
+        /// <summary>
+        /// Justified
+        /// </summary>
+        Justified
+    }
+}

--- a/src/BinaryKits.Zpl.Viewer/BinaryKits.Zpl.Viewer.csproj
+++ b/src/BinaryKits.Zpl.Viewer/BinaryKits.Zpl.Viewer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net472;netstandard2.0;net5.0</TargetFrameworks>
     <Description>This package provides a rendering logic for ZPL data</Description>
     <Company>Binary Kits Pte. Ltd.</Company>
     <Version>1.0.2</Version>
@@ -18,6 +18,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BinaryKits.Zpl.Viewer/ElementDrawers/FieldBlockElementDrawer.cs
+++ b/src/BinaryKits.Zpl.Viewer/ElementDrawers/FieldBlockElementDrawer.cs
@@ -49,7 +49,7 @@ namespace BinaryKits.Zpl.Viewer.ElementDrawers
                     typeface = SKTypeface.FromFamilyName("Arial", SKFontStyleWeight.Bold, SKFontStyleWidth.Normal, SKFontStyleSlant.Upright);
                 }
 
-                var textLines = fieldBlock.Text.Split("\\&", StringSplitOptions.RemoveEmptyEntries);
+                var textLines = fieldBlock.Text.Split(new[] { "\\&" }, StringSplitOptions.RemoveEmptyEntries);
 
                 foreach (var textLine in textLines)
                 {

--- a/src/BinaryKits.Zpl.sln
+++ b/src/BinaryKits.Zpl.sln
@@ -15,6 +15,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BinaryKits.Zpl.Labelary", "
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BinaryKits.Zpl.Viewer.WebApi", "BinaryKits.Zpl.Viewer.WebApi\BinaryKits.Zpl.Viewer.WebApi.csproj", "{0F5DFD93-782C-4FC6-AC8B-FB342E150131}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BinaryKits.Zpl.Protocol", "BinaryKits.Zpl.Protocol\BinaryKits.Zpl.Protocol.csproj", "{437A6F21-475F-4A08-BC40-D253C3AB2510}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BinaryKits.Zpl.Protocol.UnitTest", "BinaryKits.Zpl.Protocol.UnitTest\BinaryKits.Zpl.Protocol.UnitTest.csproj", "{B267DA9B-082B-4CFA-8D51-FADFD3DC8E3A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -45,6 +49,14 @@ Global
 		{0F5DFD93-782C-4FC6-AC8B-FB342E150131}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0F5DFD93-782C-4FC6-AC8B-FB342E150131}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0F5DFD93-782C-4FC6-AC8B-FB342E150131}.Release|Any CPU.Build.0 = Release|Any CPU
+		{437A6F21-475F-4A08-BC40-D253C3AB2510}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{437A6F21-475F-4A08-BC40-D253C3AB2510}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{437A6F21-475F-4A08-BC40-D253C3AB2510}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{437A6F21-475F-4A08-BC40-D253C3AB2510}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B267DA9B-082B-4CFA-8D51-FADFD3DC8E3A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B267DA9B-082B-4CFA-8D51-FADFD3DC8E3A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B267DA9B-082B-4CFA-8D51-FADFD3DC8E3A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B267DA9B-082B-4CFA-8D51-FADFD3DC8E3A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Add new project BinaryKits.Zpl.Protocol, so that the Label project could then be based on the Protocol project

```
using System;

namespace BinaryKits.Zpl.Protocol.Commands
{
    /// <summary>
    /// Command Base
    /// </summary>
    public abstract class CommandBase
    {
        /// <summary>
        /// The Command Prefix
        /// </summary>
        protected string CommandPrefix { get; private set; }

        /// <summary>
        /// Command Base
        /// </summary>
        /// <param name="commandPrefix"></param>
        public CommandBase(string commandPrefix)
        {
            this.CommandPrefix = commandPrefix;
        }

        /// <summary>
        /// Split a zpl command in data parts
        /// </summary>
        /// <param name="zplCommand"></param>
        /// <param name="dataStartIndex"></param>
        /// <returns></returns>
        protected string[] SplitCommand(string zplCommand, int dataStartIndex = 0)
        {
            var zplCommandData = zplCommand.Substring(this.CommandPrefix.Length + dataStartIndex);
            return zplCommandData.Split(',');
        }

        /// <summary>
        /// Get the Zpl Command
        /// </summary>
        /// <returns></returns>
        public abstract string ToZpl();

        /// <summary>
        /// Check the zpl command is parsable
        /// </summary>
        /// <param name="zplCommand"></param>
        /// <returns></returns>
        public bool IsCommandParsable(string zplCommand)
        {
            return zplCommand.StartsWith(this.CommandPrefix, StringComparison.OrdinalIgnoreCase);
        }

        /// <summary>
        /// Parse the Zpl Command
        /// </summary>
        /// <param name="zplCommand"></param>
        public abstract void ParseCommand(string zplCommand);
    }
}
```