### PR TITLE
Ignore missing optional parameter(s)

### DIFF
--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/ScalableBitmappedFontZplCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/ScalableBitmappedFontZplCommandAnalyzer.cs
@@ -14,10 +14,12 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
             var zplDataParts = this.SplitCommand(zplCommand, 1);
 
             var fieldOrientation = this.ConvertFieldOrientation(zplDataParts[0]);
-            _ = int.TryParse(zplDataParts[1], out var fontHeight);
-            _ = int.TryParse(zplDataParts[2], out var fontWidht);
+            var fontHeight = 0;
+            var fontWidth = 0;
+            if (zplDataParts.Length > 1) _ = int.TryParse(zplDataParts[1], out fontHeight);
+            if (zplDataParts.Length > 2) _ = int.TryParse(zplDataParts[2], out fontWidth);
 
-            this.VirtualPrinter.SetNextFont(fontName, fieldOrientation, fontWidht, fontHeight);
+            this.VirtualPrinter.SetNextFont(fontName, fieldOrientation, fontWidth, fontHeight);
 
             return null;
         }


### PR DESCRIPTION
The parameters height and width should be optional. This solution worked for us, to view GLS labels. May be there is a nicer way.