### PR TITLE
Speedup drawing of reversed elements

### DIFF
--- a/src/BinaryKits.Zpl.Viewer/ZplElementDrawer.cs
+++ b/src/BinaryKits.Zpl.Viewer/ZplElementDrawer.cs
@@ -1,4 +1,4 @@
-﻿using BinaryKits.Zpl.Label.Elements;
+using BinaryKits.Zpl.Label.Elements;
 using BinaryKits.Zpl.Viewer.ElementDrawers;
 using SkiaSharp;
 using System;
@@ -44,13 +44,33 @@ namespace BinaryKits.Zpl.Viewer
             double labelHeight = 152,
             int printDensityDpmm = 8)
         {
+            SKBitmap skBitmap = DrawBitmap(elements,labelWidth,labelHeight,printDensityDpmm);
+            using var data = skBitmap.Encode(SKEncodedImageFormat.Png, 80);
+            return data.ToArray();
+        }
+
+        /// <summary>
+        /// Draw the label to bitmap
+        /// </summary>
+        /// <param name="elements">Zpl elements</param>
+        /// <param name="labelWidth">Label width in millimeter</param>
+        /// <param name="labelHeight">Label height in millimeter</param>
+        /// <param name="printDensityDpmm">Dots per millimeter</param>
+        /// <returns></returns>
+        public SKBitmap DrawBitmap(
+            ZplElementBase[] elements,
+            double labelWidth = 102,
+            double labelHeight = 152,
+            int printDensityDpmm = 8)
+        {
             var labelImageWidth = Convert.ToInt32(labelWidth * printDensityDpmm);
             var labelImageHeight = Convert.ToInt32(labelHeight * printDensityDpmm);
 
-            using var skBitmap = new SKBitmap(labelImageWidth, labelImageHeight);
+            var skBitmap = new SKBitmap(labelImageWidth, labelImageHeight);
             using var skCanvas = new SKCanvas(skBitmap);
             skCanvas.Clear(SKColors.White);
 
+            bool drawInverted = false;
             foreach (var element in elements)
             {
                 var drawer = this._elementDrawers.SingleOrDefault(o => o.CanDraw(element));
@@ -58,27 +78,38 @@ namespace BinaryKits.Zpl.Viewer
                 {
                     if (drawer.IsReverseDraw(element))
                     {
-                        using var skBitmapInvert = new SKBitmap(skBitmap.Width, skBitmap.Height);
-                        using var skCanvasInvert = new SKCanvas(skBitmapInvert);
-
-                        drawer.Prepare(this._printerStorage, skCanvasInvert);
-
+                        drawInverted = true;
+                    } else {
+                        drawer.Prepare(this._printerStorage, skCanvas);
                         drawer.Draw(element);
-
-                        this.InvertDraw(skBitmap, skBitmapInvert);
-                        continue;
                     }
-
-                    drawer.Prepare(this._printerStorage, skCanvas);
-                    drawer.Draw(element);
-
-                    continue;
                 }
             }
 
-            using var data = skBitmap.Encode(SKEncodedImageFormat.Png, 80);
-            return data.ToArray();
+            if (drawInverted)
+            {
+                using var skBitmapInvert = new SKBitmap(skBitmap.Width, skBitmap.Height);
+                using var skCanvasInvert = new SKCanvas(skBitmapInvert);
+
+                foreach (var element in elements)
+                {
+                    var drawer = this._elementDrawers.SingleOrDefault(o => o.CanDraw(element));
+                    if (drawer != null)
+                    {
+                        if (drawer.IsReverseDraw(element))
+                        {
+                            drawer.Prepare(this._printerStorage, skCanvasInvert);
+                            drawer.Draw(element);
+                        }
+                    }
+                }
+                this.InvertDraw(skBitmap, skBitmapInvert);
+            }
+
+            return skBitmap;
         }
+
+
 
         private void InvertDraw(SKBitmap skBitmap, SKBitmap skBitmapInvert)
         {


### PR DESCRIPTION
InvertDraw calls are very slow, so this is an attempt to reduce them as much as possible by drawing only one inverted canvas for all reversed elements and even this one only if needed.
In my tests with a GLS label, the calculation time went from ~12s to 1s !