### PR TITLE
Optimize InvertDraw

### DIFF
--- a/src/BinaryKits.Zpl.Viewer/ZplElementDrawer.cs
+++ b/src/BinaryKits.Zpl.Viewer/ZplElementDrawer.cs
@@ -83,10 +83,10 @@ namespace BinaryKits.Zpl.Viewer
         private void InvertDraw(SKBitmap skBitmap, SKBitmap skBitmapInvert)
         {
             // Fast local copy
-            var originalBytes = new Span<byte>(skBitmap.Bytes);
-            var invertBytes = new Span<byte>(skBitmapInvert.Bytes);
+            var originalBytes = skBitmap.GetPixelSpan();
+            var invertBytes = skBitmapInvert.GetPixelSpan();
 
-            int total = skBitmap.Pixels.Length;
+            int total = originalBytes.Length / 4;
             for (int i = 0; i < total; i++)
             {
                 // RGBA8888

--- a/src/BinaryKits.Zpl.Viewer/ZplElementDrawer.cs
+++ b/src/BinaryKits.Zpl.Viewer/ZplElementDrawer.cs
@@ -82,40 +82,31 @@ namespace BinaryKits.Zpl.Viewer
 
         private void InvertDraw(SKBitmap skBitmap, SKBitmap skBitmapInvert)
         {
-            byte invertBlue, originalBlue;
+            // Fast local copy
             var originalBytes = new Span<byte>(skBitmap.Bytes);
             var invertBytes = new Span<byte>(skBitmapInvert.Bytes);
 
-            int total = skBitmapInvert.Pixels.Length;
+            int total = skBitmap.Pixels.Length;
             for (int i = 0; i < total; i++)
             {
                 // RGBA8888
-                int alphaByte = i * 4 + 3;
+                int alphaByte = (i << 2) + 3;
                 if (invertBytes[alphaByte] == 0)
                 {
                     continue;
                 }
-                
+
+                // Set color
                 var targetColor = SKColors.White;
-                invertBlue = invertBytes[alphaByte - 1];
-                originalBlue = originalBytes[alphaByte - 1];
-
-                if (invertBlue == originalBlue)
+                if (originalBytes[alphaByte - 1] == 255)
                 {
-                    if (invertBlue == 255)
-                    {
-                        targetColor = SKColors.Black;
-                    }
-                }
-                else
-                {
-                    if (invertBlue == 0)
-                    { 
-                        targetColor = SKColors.Black;
-                    }
+                    targetColor = SKColors.Black;
                 }
 
-                skBitmap.SetPixel(i % skBitmapInvert.Width, i / skBitmapInvert.Width, targetColor);
+                int x, y;
+                y = Math.DivRem(i, skBitmapInvert.Width, out x);
+
+                skBitmap.SetPixel(x, y, targetColor);
             }
         }
     }

--- a/src/BinaryKits.Zpl.Viewer/ZplElementDrawer.cs
+++ b/src/BinaryKits.Zpl.Viewer/ZplElementDrawer.cs
@@ -82,39 +82,40 @@ namespace BinaryKits.Zpl.Viewer
 
         private void InvertDraw(SKBitmap skBitmap, SKBitmap skBitmapInvert)
         {
-            for (var row = 0; row < skBitmapInvert.Height; row++)
+            byte invertBlue, originalBlue;
+            var originalBytes = new Span<byte>(skBitmap.Bytes);
+            var invertBytes = new Span<byte>(skBitmapInvert.Bytes);
+
+            int total = skBitmapInvert.Pixels.Length;
+            for (int i = 0; i < total; i++)
             {
-                for (var column = 0; column < skBitmapInvert.Width; column++)
+                // RGBA8888
+                int alphaByte = i * 4 + 3;
+                if (invertBytes[alphaByte] == 0)
                 {
-                    var pixelInvert = skBitmapInvert.GetPixel(column, row);
-                    if (pixelInvert.Alpha == 0)
-                    {
-                        continue;
-                    }
+                    continue;
+                }
+                
+                var targetColor = SKColors.White;
+                invertBlue = invertBytes[alphaByte - 1];
+                originalBlue = originalBytes[alphaByte - 1];
 
-                    var pixel = skBitmap.GetPixel(column, row);
-
-                    //Is black in new graphic and white in the origin
-                    if (pixelInvert.Blue == 0 && pixel.Blue == 255)
+                if (invertBlue == originalBlue)
+                {
+                    if (invertBlue == 255)
                     {
-                        skBitmap.SetPixel(column, row, SKColors.Black);
-                    }
-                    //Is black in new graphic and black in the origin (invert)
-                    else if (pixelInvert.Blue == 0 && pixel.Blue == 0)
-                    {
-                        skBitmap.SetPixel(column, row, SKColors.White);
-                    }
-                    //Is white in new graphic and white in the origin (invert)
-                    else if (pixelInvert.Blue == 255 && pixel.Blue == 255)
-                    {
-                        skBitmap.SetPixel(column, row, SKColors.Black);
-                    }
-                    //Is white in new graphic and black in the origin
-                    else if (pixelInvert.Blue == 255 && pixel.Blue == 0)
-                    {
-                        skBitmap.SetPixel(column, row, SKColors.White);
+                        targetColor = SKColors.Black;
                     }
                 }
+                else
+                {
+                    if (invertBlue == 0)
+                    { 
+                        targetColor = SKColors.Black;
+                    }
+                }
+
+                skBitmap.SetPixel(i % skBitmapInvert.Width, i / skBitmapInvert.Width, targetColor);
             }
         }
     }


### PR DESCRIPTION
https://github.com/BinaryKits/BinaryKits.Zpl/pull/64

@tinohager Do you know why we need to use color space RGBA8888, when ZPL is always black?

Anyway this reduce the time to 2s. (From 9~12s)
![image](https://user-images.githubusercontent.com/5492274/131938247-0cf7288c-c626-4791-8345-4685750cc326.png)
