### PR TITLE
Font width and height are optional

### DIFF
--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/FieldDataZplCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/FieldDataZplCommandAnalyzer.cs
@@ -90,6 +90,9 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
             var fontName = this.VirtualPrinter.NextFont.FontName;
             var fieldOrientation = this.VirtualPrinter.NextFont.FieldOrientation;
 
+            if (fontWidth == 0) fontWidth = this.VirtualPrinter.FontWidth;
+            if (fontHeight == 0) fontHeight = this.VirtualPrinter.FontHeight;
+
             return new ZplFont(fontWidth, fontHeight, fontName, fieldOrientation);
         }
     }


### PR DESCRIPTION
For example:
^AC
is valid. But currently it would set size to 0.
I am not sure if it would be better to use -1 as placeholder for "no change". This would need a change to the command parser.
Maybe it would be nicer to split the font and sizes.