### PR TITLE
^LR "Label reverse" command implementation

### DIFF
--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/FieldDataZplCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/FieldDataZplCommandAnalyzer.cs
@@ -59,7 +59,7 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
                 font = this.GetNextFontFromVirtualPrinter();
             }
 
-            var reversePrint = this.VirtualPrinter.NextElementFieldReverse;
+            var reversePrint = this.VirtualPrinter.NextElementFieldReverse || this.VirtualPrinter.LabelReverse;
 
             if (this.VirtualPrinter.NextElementFieldBlock != null)
             {

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/GraphicBoxZplCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/GraphicBoxZplCommandAnalyzer.cs
@@ -46,7 +46,7 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
                 _ = int.TryParse(zplDataParts[4], out cornerRounding);
             }
 
-            var reversePrint = this.VirtualPrinter.NextElementFieldReverse;
+            var reversePrint = this.VirtualPrinter.NextElementFieldReverse || this.VirtualPrinter.LabelReverse;
 
             return new ZplGraphicBox(x, y, widht, height, borderThickness, lineColor, cornerRounding, reversePrint, bottomToTop);
         }

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/LabelReversePrintZplCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/LabelReversePrintZplCommandAnalyzer.cs
@@ -1,0 +1,16 @@
+﻿using BinaryKits.Zpl.Label.Elements;
+
+namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
+{
+    public class LabelReversePrintZplCommandAnalyzer : ZplCommandAnalyzerBase
+    {
+        public LabelReversePrintZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^LR", virtualPrinter)
+        { }
+
+        public override ZplElementBase Analyze(string zplCommand)
+        {
+            this.VirtualPrinter.SetLabelReverse(zplCommand[3] == 'Y' || zplCommand[3] == 'y');
+            return null;
+        }
+    }
+}

--- a/src/BinaryKits.Zpl.Viewer/VirtualPrinter.cs
+++ b/src/BinaryKits.Zpl.Viewer/VirtualPrinter.cs
@@ -21,7 +21,7 @@ namespace BinaryKits.Zpl.Viewer
         public FontInfo NextFont { get; private set; }
 
         public bool NextElementFieldReverse { get; private set; }
-
+        public bool LabelReverse { get; private set; }
         public BarcodeInfo BarcodeInfo { get; private set; }
 
         public VirtualPrinter()
@@ -77,6 +77,11 @@ namespace BinaryKits.Zpl.Viewer
         public void SetNextElementFieldReverse()
         {
             this.NextElementFieldReverse = true;
+        }
+
+        public void SetLabelReverse(bool reverse)
+        {
+            this.LabelReverse = reverse;
         }
 
         public void ClearNextElementFieldReverse()

--- a/src/BinaryKits.Zpl.Viewer/ZplAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/ZplAnalyzer.cs
@@ -39,6 +39,7 @@ namespace BinaryKits.Zpl.Viewer
                 new FieldBlockZplCommandAnalyzer(this._virtualPrinter),
                 new FieldDataZplCommandAnalyzer(this._virtualPrinter),
                 new FieldReversePrintZplCommandAnalyzer(this._virtualPrinter),
+                new LabelReversePrintZplCommandAnalyzer(this._virtualPrinter),
                 new FieldSeparatorZplCommandAnalyzer(this._virtualPrinter),
                 new FieldTypesetZplCommandAnalyzer(this._virtualPrinter),
                 new FieldOriginZplCommandAnalzer(this._virtualPrinter),


### PR DESCRIPTION
Simply added a global reverse switch, controlled by the ^LRY / ^LRN command.
P.S.: Reverse is working only once - so reversing the label and reversing an element is NOT a double reverse. Otherwise I would have used xor ( this.VirtualPrinter.NextElementFieldReverse ^ this.VirtualPrinter.LabelReverse).