### PR TITLE
Change Viewer & Laberary TargetFramework to netstandard2.0

### DIFF
--- a/src/BinaryKits.Zpl.Labelary/BinaryKits.Zpl.Labelary.csproj
+++ b/src/BinaryKits.Zpl.Labelary/BinaryKits.Zpl.Labelary.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
     <Description>This package provides a client for the Labelary API for rendering ZPL data</Description>
     <Company>Binary Kits Pte. Ltd.</Company>
     <Version>1.0.1</Version>

--- a/src/BinaryKits.Zpl.Viewer/BinaryKits.Zpl.Viewer.csproj
+++ b/src/BinaryKits.Zpl.Viewer/BinaryKits.Zpl.Viewer.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net472;netstandard2.0;net5.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
     <Description>This package provides a rendering logic for ZPL data</Description>
     <Company>Binary Kits Pte. Ltd.</Company>
     <Version>1.0.4</Version>

--- a/src/BinaryKits.Zpl.Viewer/ElementDrawers/FieldBlockElementDrawer.cs
+++ b/src/BinaryKits.Zpl.Viewer/ElementDrawers/FieldBlockElementDrawer.cs
@@ -49,7 +49,7 @@ namespace BinaryKits.Zpl.Viewer.ElementDrawers
                     typeface = SKTypeface.FromFamilyName("Arial", SKFontStyleWeight.Bold, SKFontStyleWidth.Normal, SKFontStyleSlant.Upright);
                 }
 
-                var textLines = fieldBlock.Text.Split("\\&", StringSplitOptions.RemoveEmptyEntries);
+                var textLines = fieldBlock.Text.Split(new[] { "\\&" }, StringSplitOptions.RemoveEmptyEntries);
 
                 foreach (var textLine in textLines)
                 {


### PR DESCRIPTION
Since the Viewer project targeted netstandard2.1, it's not possible to use it from a .NET Framework 4.7.2 project.

This PR includes the code changes required for the older C# version, including a `string.Split(string)` call and a number of `using var x = new X();` style usings.

The change of `using` style makes for an ugly diff, but only includes adding the required parentheses and curly braces.  It's possible to avoid changing the `using`s by adding a `<LangVersion>latest</LangVersion>` to the .csproj file, but I'm not sure if that's a suitable solution.  I have [another branch](https://github.com/BinaryKits/BinaryKits.Zpl/compare/master...DavidBoone:netstandard20-LangVersion) which uses that method, I'd be happy to switch this PR, or close & open a new PR with that solution, let me know.  