### PR TITLE
Add support for Field Hexadecimal Indicator(^FH)

### DIFF
--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/FieldHexadecimalZplCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/FieldHexadecimalZplCommandAnalyzer.cs
@@ -1,0 +1,24 @@
+﻿using BinaryKits.Zpl.Label.Elements;
+using BinaryKits.Zpl.Viewer.Helpers;
+
+namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
+{
+    public class FieldHexadecimalZplCommandAnalyzer : ZplCommandAnalyzerBase
+    {
+        public FieldHexadecimalZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^FH", virtualPrinter)
+        { }
+        public override ZplElementBase Analyze(string zplCommand)
+        {
+            var zplDataParts = this.SplitCommand(zplCommand);
+
+            char Indicator = '_';
+
+            if (zplDataParts.Length > 0)
+            {
+                Indicator = zplDataParts[0][0];
+            }
+            StringHelper.ReplaceChar = Indicator;
+            return null;
+        }
+    }
+}

--- a/src/BinaryKits.Zpl.Viewer/ElementDrawers/FieldBlockElementDrawer.cs
+++ b/src/BinaryKits.Zpl.Viewer/ElementDrawers/FieldBlockElementDrawer.cs
@@ -1,5 +1,6 @@
 ﻿using BinaryKits.Zpl.Label;
 using BinaryKits.Zpl.Label.Elements;
+using BinaryKits.Zpl.Viewer.Helpers;
 using SkiaSharp;
 using System;
 
@@ -49,7 +50,7 @@ namespace BinaryKits.Zpl.Viewer.ElementDrawers
                     typeface = SKTypeface.FromFamilyName("Arial", SKFontStyleWeight.Bold, SKFontStyleWidth.Normal, SKFontStyleSlant.Upright);
                 }
 
-                var textLines = fieldBlock.Text.Split(new[] { "\\&" }, StringSplitOptions.RemoveEmptyEntries);
+                var textLines = fieldBlock.Text.ReplaceSpecialChars().Split(new[] { "\\&" }, StringSplitOptions.RemoveEmptyEntries);
 
                 foreach (var textLine in textLines)
                 {

--- a/src/BinaryKits.Zpl.Viewer/ElementDrawers/TextFieldElementDrawer.cs
+++ b/src/BinaryKits.Zpl.Viewer/ElementDrawers/TextFieldElementDrawer.cs
@@ -1,4 +1,5 @@
 ﻿using BinaryKits.Zpl.Label.Elements;
+using BinaryKits.Zpl.Viewer.Helpers;
 using SkiaSharp;
 
 namespace BinaryKits.Zpl.Viewer.ElementDrawers
@@ -55,8 +56,9 @@ namespace BinaryKits.Zpl.Viewer.ElementDrawers
 
                 var textBounds = new SKRect();
                 var textBoundBaseline = new SKRect();
-                skPaint.MeasureText(new string('A', textField.Text.Length), ref textBoundBaseline);
-                skPaint.MeasureText(textField.Text, ref textBounds);
+                string DisplayText = textField.Text.ReplaceSpecialChars();
+                skPaint.MeasureText(new string('A', DisplayText.Length), ref textBoundBaseline);
+                skPaint.MeasureText(DisplayText, ref textBounds);
 
                 if (textField.FieldTypeset != null)
                 {
@@ -117,7 +119,7 @@ namespace BinaryKits.Zpl.Viewer.ElementDrawers
                         this._skCanvas.SetMatrix(matrix);
                     }
 
-                    this._skCanvas.DrawText(textField.Text, x, y, new SKFont(typeface, fontSize, scaleX, 0), skPaint);
+                    this._skCanvas.DrawText(DisplayText, x, y, new SKFont(typeface, fontSize, scaleX, 0), skPaint);
                 }
             }
         }

--- a/src/BinaryKits.Zpl.Viewer/Helpers/StringHelper.cs
+++ b/src/BinaryKits.Zpl.Viewer/Helpers/StringHelper.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+
+namespace BinaryKits.Zpl.Viewer.Helpers
+{
+    public static class StringHelper
+    {
+        /// <summary>
+        /// The hexadecimal indicator from the ^FH
+        /// </summary>
+        public static char ReplaceChar { get; set; } = '_';
+
+        /// <summary>
+        /// Search for the Hexadecimal indicator and replaces it with the HEX char
+        /// </summary>
+        /// <param name="text">String to search in</param>
+        /// <returns>Output string</returns>
+        public static string ReplaceSpecialChars(this string text)
+        {
+            if (!text.Contains(ReplaceChar))
+                return text;
+
+            StringBuilder sb = new StringBuilder();
+            for (int i = 0; i < text.Length; i++)
+            {
+                if (text[i] == ReplaceChar)
+                {
+                    string temp = text.Substring(i + 1, 2);
+                    sb.Append((char)Int16.Parse(temp, NumberStyles.AllowHexSpecifier));
+                    i = i + 2;
+                }
+                else
+                {
+                    sb.Append(text[i]);
+                }
+
+            }
+            return sb.ToString();
+        }
+    }
+}

--- a/src/BinaryKits.Zpl.Viewer/ZplAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/ZplAnalyzer.cs
@@ -38,6 +38,7 @@ namespace BinaryKits.Zpl.Viewer
                 new DownloadObjectsZplCommandAnaylzer(this._virtualPrinter, this._printerStorage),
                 new FieldBlockZplCommandAnalyzer(this._virtualPrinter),
                 new FieldDataZplCommandAnalyzer(this._virtualPrinter),
+                new FieldHexadecimalZplCommandAnalyzer(this._virtualPrinter),
                 new FieldReversePrintZplCommandAnalyzer(this._virtualPrinter),
                 new LabelReversePrintZplCommandAnalyzer(this._virtualPrinter),
                 new FieldSeparatorZplCommandAnalyzer(this._virtualPrinter),


### PR DESCRIPTION
Example:
```
^XA
^LH0,0
^CI28

^A0N,50,50
^FO50,100
^FH^FD[_5F_7E_5E][LineBreak ][The quick fox jumps over the lazy dog.]^FS
^FO50,150
^FH^FB300,1,0,C,0^FD[_5F_7E_5E][LineBreak ][The quick fox jumps over the lazy dog.]^FS
^XZ
```