### PR TITLE
show rendering error

### DIFF
--- a/src/BinaryKits.Zpl.Viewer.WebApi/Controllers/ViewerController.cs
+++ b/src/BinaryKits.Zpl.Viewer.WebApi/Controllers/ViewerController.cs
@@ -21,6 +21,18 @@ namespace BinaryKits.Zpl.Viewer.WebApi.Controllers
         [HttpPost]
         public ActionResult<RenderResponseDto> Render(RenderRequestDto request)
         {
+            try
+            {
+                return RenderZpl(request);
+            }
+            catch (Exception ex)
+            {
+                return this.StatusCode(StatusCodes.Status500InternalServerError, ex.Message);
+            }
+        }
+
+        private ActionResult<RenderResponseDto> RenderZpl(RenderRequestDto request)
+        {
             IPrinterStorage printerStorage = new PrinterStorage();
             var drawer = new ZplElementDrawer(printerStorage);
 

--- a/src/BinaryKits.Zpl.Viewer.WebApi/wwwroot/index.html
+++ b/src/BinaryKits.Zpl.Viewer.WebApi/wwwroot/index.html
@@ -63,6 +63,10 @@
                             </ul>
                         </div>
                     </div>
+                    <div v-if="renderError" class="alert alert-warning mt-1" role="alert">
+                        <h4>Label rendering error</h4>
+                        <pre>{{ renderError }}</pre>
+                    </div>
                 </div>
             </div>
         </div>
@@ -83,6 +87,7 @@
                     zplData: null,
                     labels: null,
                     renderResponse: null,
+                    renderError: null,
                     printDensityDpmm: 8,
                     labelWidth: 102,
                     labelHeight: 152,
@@ -136,6 +141,7 @@
                     await this.render()
                 },
                 async render() {
+                    this.renderError = null
                     try {
                         this.loadingPreview = true
                         const payload = {
@@ -146,7 +152,11 @@
                         }
                         const response = await axios.post('api/v1/viewer', payload)
                         this.renderResponse = response.data
-                    } finally {
+                    } catch (err) {
+                        this.renderError = err.response.data
+                        console.error(this.renderError)
+                    }
+                    finally {
                         this.loadingPreview = false
                     }
                 },

--- a/src/BinaryKits.Zpl.Viewer.WebApi/wwwroot/index.html
+++ b/src/BinaryKits.Zpl.Viewer.WebApi/wwwroot/index.html
@@ -154,6 +154,7 @@
                         this.renderResponse = response.data
                     } catch (err) {
                         this.renderError = err.response.data
+                        this.renderResponse = null
                         console.error(this.renderError)
                     }
                     finally {

--- a/src/BinaryKits.Zpl.Viewer/ZplElementDrawer.cs
+++ b/src/BinaryKits.Zpl.Viewer/ZplElementDrawer.cs
@@ -79,9 +79,16 @@ namespace BinaryKits.Zpl.Viewer
 
                     continue;
                 }
-                catch (Exception exception)
+                catch (Exception ex)
                 {
-                    //log error
+                    if (element is ZplBarcode)
+                    {
+                        throw new Exception($"Error on zpl element \"{(element as ZplBarcode).Content}\": {ex.Message}");
+                    }
+                    else
+                    {
+                        throw ex;
+                    }
                 }
             }
 


### PR DESCRIPTION
Fix https://github.com/BinaryKits/BinaryKits.Zpl/issues/84

![image](https://user-images.githubusercontent.com/5492274/140628796-24fa4a24-eff6-4add-bd3a-30b777d175c1.png)

@tinohager Not sure why only `ZplBarcode` has the `Content`. We need the raw command kept for error reporting?
