### PR TITLE
If next element is not a FieldBlock on FieldData, reverse print was n…

### DIFF
--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/FieldDataZplCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/FieldDataZplCommandAnalyzer.cs
@@ -85,7 +85,7 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
                 var textJustification = this.VirtualPrinter.NextElementFieldBlock.TextJustification;
                 var lineSpace = this.VirtualPrinter.NextElementFieldBlock.AddOrDeleteSpaceBetweenLines;
 
-                return new ZplFieldBlock(text, x, y, width, font, maxLineCount, lineSpace, textJustification);
+                return new ZplFieldBlock(text, x, y, width, font, maxLineCount, lineSpace, textJustification, reversePrint : reversePrint);
             }
 
             return new ZplTextField(text, x, y, font, reversePrint: reversePrint, bottomToTop: bottomToTop);


### PR DESCRIPTION
If a FieldData was marked as reverse print and the next element in virtual printer is not a FieldBlock a ZplFieldBlock was returned without reverse print 

**Before**:
![label0NOREVERSE](https://user-images.githubusercontent.com/19358221/172069423-4a1a7421-9f43-437f-9727-b29d8c44aadb.png)

**After**:
![label0](https://user-images.githubusercontent.com/19358221/172069433-a8729a73-f97b-4a52-bd46-899017491e97.png)

**This is the first case (the XHP1 one):**
```
^FO20,150^GB210,45,45^FS 
^FO20,156^A0N,45,45^FB210,1,0,C^FR^FDXHP1^FS 
```

**Complete ZPL:**
```
^XA ^MCY ^CI28 ^LH5,15 ^FX HEADER ^FS ^FX Logo_Meli ^FS ^FO20,10^GFA,800,800,10,,:::::::::::O0FF,M07JFE,L07FC003FE,K07EL07E,J01EN078,J07P0E,I01CP038,I07R0E,001CK01FK038,003L0IFK0C,0078J03803CJ0E,0187J06I07I01D8,0300F00F8J0FEFE0C,02003IFK01J06,04I01C6P02,08K0401FM01,1L08060CM083K0100C02M0C2M01001M046K0306I0CL064K0198I02L024Q01L02CR08K03CR04K03FR02K03FFQ01J07!C1FQ0C007E3C03EP0203F03C0078O010F003CI0EF1N0F8003CI070C4M06I03CI02003CL02I03CI02P02I036I03N0106I066I01J08J0C4I067J0EI08J078I0E38I03I0E00406I01C3CI01800100204I01C3CJ0FI080118I03C1EJ03800801FJ0780FK0C008018J0F,078J07C0823J01F,07EJ01C1C36J07E,03FK031C3K0FC,01FCJ01E18J01F8,00FER07F,007F8P01FE,003FFP0FFC,I0FFEN07FF,I03FFCL03FFC,J0IFCJ03IF,J07PFE,K0PF,K01NF8,L01LF8,N0JF,,:::::::::::^FS ^FO120,20^A0N,24,24^FH^FDRemitente #430819330^FS ^FO120,43^A0N,24,24^FB550,2,0,L^FH^FDMineral de la Reforma_2C Hgo_2E s/n ^FS ^FO120,90^A0N,24,24^FB550,2,0,L^FH^FDMineral De La Reforma, MX-HID- 42186^FS ^FO120,120^A0N,24,24^FDVenta: 20000^FS ^FO250,117^A0N,27,27^FD03660662992^FS ^FX LAST CLUSTER ^FS ^FO20,150^GB210,45,45^FS ^FO20,156^A0N,45,45^FB210,1,0,C^FR^FDXHP1^FS ^FX END LAST CLUSTER ^FS ^FO480,150^GB330,40,40^FS ^FO410,160^A0N,22,22 ^FB460,1,0,C^FR^FH^FDENTREGAR A COLECTA^FS ^FX Shipment_Number_Bar_Code ^FS ^FO230,210^BY3,,0^BCN,160,N,N,N^FD>:41420276965^FS ^FO95,385^A0N,30,30^FB390,1,0,R^FD414202^FS ^FO488,381^A0N,35,35^FB400,1,0,L^FD76965^FS ^FX END_HEADER ^FS ^FX CUSTOM_DATA ^FS ^FX CUSTOM_DATA ^FS ^FO0,750^A0N,175,175^FB630,1,0,R^FDSMX1^FS ^FO670,800^A0N,48,48^FB200,1,0,L^FD20:30^FS ^FO0,1000^A0N,28,28^FB600,1,0,R^FDXHP1 > XEM1 > SMX1 > ^FS ^FO605,995^A0N,40,40^FDA1_3^FS ^FO0,1080^A0N,40,40^FB820,1,0,C^FDJUE 09/06/2022^FS ^FO0,1130^A0N,40,40^FB820,1,0,C^FDCP: 11520^FS ^FO0,1350^GB850,0,2^FS ^FX END CUSTOM_DATA ^FS ^FX RECEIVER ZONE ^FS ^FO30,1365^A0N,26,26^FB600,2,0,L^FH^FDMa Luisa Belmonte Gonzalez (LUISABELMONTE84)^FS ^FO30,1415^A0N,26,26^FB600,2,0,L^FH^FDDomicilio: Av Ejercito Nacional 843, Miguel Hidalgo, Distrito Federal^FS ^FO29,1414^A0N,26,26^FH^FDDomicilio:^FS ^FO30,1475^A0N,26,26^FDCP: 11520^FS ^FO29,1474^A0N,26,26^FDCP: 11520^FS ^FO30,1505^A0N,26,26^FB600,1,0,L^FH^FDColonia: Granada^FS ^FO31,1505^A0N,26,26^FB600,1,0,L^FDColonia:^FS ^FO30,1534^A0N,26,26^FB600,5,0,L^FH^FDReferencia: Referencia: Dentro De Plaza Antara Por Donde Esta Play City Zona De Bancos Estoy En Bbva estoy hasta las 4 pm^FS ^FO29,1533^A0N,26,26^FDReferencia:^FS ^FX QR Code ^FS ^FO650,1395^BY2,2,0^BQN,2,5^FDLA,{\"id\":\"41420276965\",\"t\":\"lm\"}^FS ^FO650,1535^GB105,40,40^FS ^FO650,1540^A0N,35,35 ^FB105,1,0,C^FR^FDC^FS ^FX END_FOOTER ^FS ^XZ ^XA ^MCY ^CI28 ^LH5,15 ^FX HEADER ^FS ^FX Logo_Meli ^FS ^FO20,10^GFA,800,800,10,,:::::::::::O0FF,M07JFE,L07FC003FE,K07EL07E,J01EN078,J07P0E,I01CP038,I07R0E,001CK01FK038,003L0IFK0C,0078J03803CJ0E,0187J06I07I01D8,0300F00F8J0FEFE0C,02003IFK01J06,04I01C6P02,08K0401FM01,1L08060CM083K0100C02M0C2M01001M046K0306I0CL064K0198I02L024Q01L02CR08K03CR04K03FR02K03FFQ01J07!C1FQ0C007E3C03EP0203F03C0078O010F003CI0EF1N0F8003CI070C4M06I03CI02003CL02I03CI02P02I036I03N0106I066I01J08J0C4I067J0EI08J078I0E38I03I0E00406I01C3CI01800100204I01C3CJ0FI080118I03C1EJ03800801FJ0780FK0C008018J0F,078J07C0823J01F,07EJ01C1C36J07E,03FK031C3K0FC,01FCJ01E18J01F8,00FER07F,007F8P01FE,003FFP0FFC,I0FFEN07FF,I03FFCL03FFC,J0IFCJ03IF,J07PFE,K0PF,K01NF8,L01LF8,N0JF,,:::::::::::^FS ^FO120,20^A0N,24,24^FH^FDRemitente #430819330^FS ^FO120,43^A0N,24,24^FB550,2,0,L^FH^FDMineral de la Reforma_2C Hgo_2E s/n ^FS ^FO120,90^A0N,24,24^FB550,2,0,L^FH^FDMineral De La Reforma, MX-HID- 42186^FS ^FO120,120^A0N,24,24^FDVenta: 20000^FS ^FO250,117^A0N,27,27^FD03661414842^FS ^FX LAST CLUSTER ^FS ^FO20,150^GB210,45,45^FS ^FO20,156^A0N,45,45^FB210,1,0,C^FR^FDXHP1^FS ^FX END LAST CLUSTER ^FS ^FO480,150^GB330,40,40^FS ^FO410,160^A0N,22,22 ^FB460,1,0,C^FR^FH^FDENTREGAR A COLECTA^FS ^FX Shipment_Number_Bar_Code ^FS ^FO230,210^BY3,,0^BCN,160,N,N,N^FD>:41420604868^FS ^FO95,385^A0N,30,30^FB390,1,0,R^FD414206^FS ^FO488,381^A0N,35,35^FB400,1,0,L^FD04868^FS ^FX END_HEADER ^FS ^FX CUSTOM_DATA ^FS ^FX CUSTOM_DATA ^FS ^FO0,750^A0N,175,175^FB630,1,0,R^FDSQR1^FS ^FO670,800^A0N,48,48^FB200,1,0,L^FD20:30^FS ^FO0,1000^A0N,28,28^FB600,1,0,R^FDXHP1 > XEM1 > SQR1 > ^FS ^FO605,995^A0N,40,40^FDA3_2^FS ^FO0,1080^A0N,40,40^FB820,1,0,C^FDVIE 10/06/2022^FS ^FO0,1130^A0N,40,40^FB820,1,0,C^FDCP: 76904^FS ^FO0,1350^GB850,0,2^FS ^FX END CUSTOM_DATA ^FS ^FX RECEIVER ZONE ^FS ^FO30,1365^A0N,26,26^FB600,2,0,L^FH^FDPaola Morales (PAS12345)^FS ^FO30,1415^A0N,26,26^FB600,2,0,L^FH^FDDomicilio: Ocal 19, Corregidora, Quer_C3_A9taro^FS ^FO29,1414^A0N,26,26^FH^FDDomicilio:^FS ^FO30,1475^A0N,26,26^FDCP: 76904^FS ^FO29,1474^A0N,26,26^FDCP: 76904^FS ^FO30,1505^A0N,26,26^FB600,1,0,L^FH^FDColonia: Los Olvera^FS ^FO31,1505^A0N,26,26^FB600,1,0,L^FDColonia:^FS ^FO30,1534^A0N,26,26^FB600,5,0,L^FH^FDReferencia: Referencia: Zaguanes Negros_2C Fachada Gris Entre: Fresno_2C Naranjo_2E Cipres Norte y Ahuehuete^FS ^FO29,1533^A0N,26,26^FDReferencia:^FS ^FX QR Code ^FS ^FO650,1395^BY2,2,0^BQN,2,5^FDLA,{\"id\":\"41420604868\",\"t\":\"lm\"}^FS ^FO650,1535^GB105,40,40^FS ^FO650,1540^A0N,35,35 ^FB105,1,0,C^FR^FDR^FS ^FX END_FOOTER ^FS ^XZ
```