### PR TITLE
Long barcode 128 on a long string

### DIFF
--- a/src/BinaryKits.Zpl.Viewer/ElementDrawers/Barcode128ElementDrawer.cs
+++ b/src/BinaryKits.Zpl.Viewer/ElementDrawers/Barcode128ElementDrawer.cs
@@ -32,7 +32,13 @@ namespace BinaryKits.Zpl.Viewer.ElementDrawers
                     Height = barcode.Height
                 };
 
-                using var image = barcodeElement.Encode(TYPE.CODE128B, barcode.Content);
+                Image? image;
+                if( content.Length < 12 ){
+                    image = barcodeElement.Encode(TYPE.CODE128B, barcode.Content);
+                } else {
+                    image = barcodeElement.Encode(TYPE.CODE128, barcode.Content);
+                }
+                
                 this.DrawBarcode(this.GetImageData(image), barcode.Height, image.Width, barcode.FieldOrigin != null, x, y, barcode.FieldOrientation);
             }
         }


### PR DESCRIPTION
Hi I was trying to create a Barcode 128 with a 34 character string and the result was a very long barcode.

After some try and error, I got to the conclusion that strings that are less than 12 in length can be rendered well with  CODE128B type, and if length is greater than 11 will be rendered well with CODE128 or CODE128C type. 

Examples:

**Error**
string: "1013486130441141878600786403467495"
Image width: 1227
Rendered barcode(The big black line at the end is the background of my image viewer):
![2022-06-06_17-06](https://user-images.githubusercontent.com/19358221/172268915-aa548465-3670-4536-80d4-a42d24547024.png)

**Solution**
string: "1013486130441141878600786403467495"
Image width: 666
Rendered barcode:
![2022-06-06_17-08](https://user-images.githubusercontent.com/19358221/172269031-87a323c3-ff01-4466-9614-4909720a6e10.png)

If you read the resulting barcode from solution, all will be correct.

Thank you!

Used zpl:
```
^XA
^MCY
^CI28
^LH5,15
^FX  HEADER  ^FS
^FX  Logo_Meli  ^FS
^FO20,10^GFA,800,800,10,,:::::::::::O0FF,M07JFE,L07FC003FE,K07EL07E,J01EN078,J07P0E,I01CP038,I07R0E,001CK01FK038,003L0IFK0C,0078J03803CJ0E,0187J06I07I01D8,0300F00F8J0FEFE0C,02003IFK01J06,04I01C6P02,08K0401FM01,1L08060CM083K0100C02M0C2M01001M046K0306I0CL064K0198I02L024Q01L02CR08K03CR04K03FR02K03FFQ01J07!C1FQ0C007E3C03EP0203F03C0078O010F003CI0EF1N0F8003CI070C4M06I03CI02003CL02I03CI02P02I036I03N0106I066I01J08J0C4I067J0EI08J078I0E38I03I0E00406I01C3CI01800100204I01C3CJ0FI080118I03C1EJ03800801FJ0780FK0C008018J0F,078J07C0823J01F,07EJ01C1C36J07E,03FK031C3K0FC,01FCJ01E18J01F8,00FER07F,007F8P01FE,003FFP0FFC,I0FFEN07FF,I03FFCL03FFC,J0IFCJ03IF,J07PFE,K0PF,K01NF8,L01LF8,N0JF,,:::::::::::^FS
^FO130,20^A0N,24,24^FH^FDTest Test #351646309^FS
^FO130,43^A0N,24,24^FB590,3,0,L^FH^FDREYES 142, SAN BENITO, Hermosillo, MX-SON - 83190, Referencia: CAMPECHE Y TABASCO^FS
^FO120,120^A0N,24,24^FDPack ID: 20000^FS
^FO272,117^A0N,27,27^FD03596019369^FS
^FX  Shipment_Number_Bar_Code  ^FS
^FO160,210^BY3,,0^BCN,160,N,N,N^FD>:41427426249^FS
^FO0,385^A0N,30,30^FB404,1,0,R^FD4142742^FS
^FO405,380^A0N,35,35^FB404,1,0,L^FD6249^FS
^FX  END_HEADER  ^FS
^FX  CUSTOM_DATA  ^FS
^FO0,560^GB810,1,1^FS
^FX CUSTOM_DATA ^FS
^FO40,600^GFA,728,728,14,,:3IFEN01KFC,3JFN03KFC,:::::3FCP03IF8,3FCP03IF,3FCP03IF8,3FCI03CI01C3IF,3FC001FFC00FFBIF801K01,3IFE7FFE03NFDFF01FF,3IFEJF07NFCFF83FE,3NF8OFC7FC7FC,3KFC3FCOFC3FEFF8,3KF80FDFF0LFC1JF,3KF80IFE07KFC0IFE,3FC03LFC03IF8I0IFC,3FC07LFC03IFJ07FF8,3FC07LFC03IFJ03FF,3FC07LFC03IFJ01FF,3FC07LFC03IFJ03FF8,3FC03FI01FC03IF8I07FFC,3FC03F8001FE07KFC0IFE,3FC03FC1JF0LFC1JF,3FC01FE3FCOFC3FEFF8,3FC01JF8OFC7FCFFC,3FC00JF87NFCFF87FC,3FC007IF03NFDFF03FE,3FC001FFC01FFBMFE01FF,L07FI07E,,::U07E,U04,:U040023811870C,U04046C4664C93,U07E24C244283,U04018824C2C18,U04018824C038E,U0402882440081,U04064C64428A1,U07E42FC43CD9E,Y08,::,^FS
^FO150,600^A0N,60,60^FB135,70,,R^FD511^FS
^FO290,575^GB90,90,8^FS
^FO315,595^A0N,70,70^FDE^FS
^FO240,670^A0N,20,20^FDJ162016070501uv^FS
^FX  Side info  ^FS
^FO530,560^GB283,270,1^FS
^FO540,580^A0N,22,22^FDFecha^FS
^FO540,610^A0N,35,35^FD06-06-2022^FS
^FO541,610^A0N,35,35^FD06-06-2022^FS
^FO540,670^A0N,22,22^FH^FDDimensi_C3_B3n^FS
^FO540,700^A0N,35,35^FD78x27x38^FS
^FO541,700^A0N,35,35^FD78x27x38^FS
^FO540,760^A0N,22,22^FDPeso^FS
^FO540,790^A0N,35,35^FD7,374 g^FS
^FO541,790^A0N,35,35^FD7,374 g^FS
^FX  End side info  ^FS
^FO40,805^A0N,25,25^FDTRK#^FS
^FO36,830^GB54,30,1^FS
^FO42,835^A0N,22,22^FD0455^FS
^FO110,815^A0N,35,25^FD786403467495^FS
^FO40,910^A0N,60,60^FDMCVIBA^FS
^FO40,975^A0N,30,25^FDBILL THIRD PARTY^FS
^FO500,840^A0N,40,38^FB260,1,0,R^FDAT^FS
^FO500,880^A0N,30,28^FB260,2,0,R^FDECONOMY^FS
^FO500,920^A0N,40,38^FB260,1,0,R^FD^FS
^FO500,960^A0N,40,38^FB260,1,0,R^FD86750^FS
^FO520,1005^A0N,30,28^FB180,1,0,R^FDTB-MX^FS
^FO710,1000^A0N,36,30^FB80,1,0,L^FDMIA^FS
^FO60,1060^BY3,2,0^BCN,200,N,N,N,N^FD>;1013486130441141878600786403467495^FS
^FO10,1270^A0N,28,28^FB800,1,0,C^FDTRCK: 786403467495^FS
^FO10,1300^A0N,27,27^FB800,1,0,C^FDSvcs: ECONOMY^FS^FO0,1350^GB850,0,2^FS
^FX  END CUSTOM_DATA  ^FS
^FX  RECEIVER ZONE  ^FS
^FO30,1365^A0N,26,26^FB600,2,0,L^FH^FDFernando Test (TETE548341)^FS
^FO30,1415^A0N,26,26^FB600,2,0,L^FH^FDDomicilio: Falasd 1212, Hermosillo, Sonora^FS
^FO29,1414^A0N,26,26^FH^FDDomicilio:^FS
^FO30,1475^A0N,26,26^FDCP: 83190^FS
^FO29,1474^A0N,26,26^FDCP: 83190^FS
^FO230,1475^A0N,26,26^FH^FDCentral: +525592256009^FS
^FO229,1474^A0N,26,26^FH^FDCentral: +525592256009^FS
^FO30,1505^A0N,26,26^FB600,1,0,L^FH^FDColonia: San beno^FS
^FO31,1505^A0N,26,26^FB600,1,0,L^FDColonia:^FS
^FO30,1534^A0N,26,26^FB600,5,0,L^FH^FDReferencia: Referencia: Entre Caballo Y Vecerro^FS
^FO29,1533^A0N,26,26^FDReferencia:^FS
^FX  QR Code  ^FS
^FO650,1395^BY2,2,0^BQN,2,5^FDLA,{"id":"41427426249","t":"lm"}^FS
^FO650,1535^GB105,40,40^FS
^FO650,1540^A0N,35,35
^FB105,1,0,C^FR^FDR^FS
^FX  END_FOOTER  ^FS
^XZ
```

