### PR TITLE
FieldBlock Centering problem

### DIFF
--- a/src/BinaryKits.Zpl.Viewer/ElementDrawers/FieldBlockElementDrawer.cs
+++ b/src/BinaryKits.Zpl.Viewer/ElementDrawers/FieldBlockElementDrawer.cs
@@ -59,6 +59,8 @@ namespace BinaryKits.Zpl.Viewer.ElementDrawers
                     skPaint.Typeface = typeface;
                     skPaint.TextSize = fontSize;
                     skPaint.TextScaleX = scaleX;
+                    //Reset the X point for the next row
+                    x = fieldBlock.PositionX;
 
                     var textBounds = new SKRect();
                     var textBoundBaseline = new SKRect();


### PR DESCRIPTION
Fixes the problem that if you center a Field Block it will only center the first line.
The next lines will be centered from the start point of the line before.
![FieldBlock](https://user-images.githubusercontent.com/6353023/173516385-bcb74ea5-8ef6-41ff-b1ab-5f704ba97f69.png)
```
^XA
^CF0,30
^FO32,54^GB120,80,2^FS
^FO32,60^FB120,3,0,C,0^FDLine1\&Line2\&Line3^FS
^XZ
```