### PR TITLE
Render interpretation line for Barcode128

### DIFF
--- a/src/BinaryKits.Zpl.Viewer/ElementDrawers/Barcode128ElementDrawer.cs
+++ b/src/BinaryKits.Zpl.Viewer/ElementDrawers/Barcode128ElementDrawer.cs
@@ -37,7 +37,7 @@ namespace BinaryKits.Zpl.Viewer.ElementDrawers
                 var labelTypeface = options.FontLoader("1");
                 var labelFont = new SKFont(labelTypeface, labelFontSize);
                 labelFont.GetFontMetrics(out var labelFontMetrics);
-                int labelHeight = (int)Math.Ceiling((labelFontMetrics.Bottom - labelFontMetrics.Top) + labelFontMetrics.Descent);
+                int labelHeight = barcode.PrintInterpretationLine ? (int)Math.Ceiling((labelFontMetrics.Bottom - labelFontMetrics.Top) + labelFontMetrics.Descent) : 0;
 
                 var barcodeElement = new Barcode {
                     BarWidth = barcode.ModuleWidth,

--- a/src/BinaryKits.Zpl.Viewer/ElementDrawers/Barcode128ElementDrawer.cs
+++ b/src/BinaryKits.Zpl.Viewer/ElementDrawers/Barcode128ElementDrawer.cs
@@ -2,7 +2,6 @@ using BarcodeLib;
 using BinaryKits.Zpl.Label.Elements;
 using BinaryKits.Zpl.Viewer.Helpers;
 using SkiaSharp;
-using System;
 using System.Drawing;
 
 namespace BinaryKits.Zpl.Viewer.ElementDrawers
@@ -35,9 +34,8 @@ namespace BinaryKits.Zpl.Viewer.ElementDrawers
 
                 float labelFontSize = barcode.ModuleWidth * 7.25f;
                 var labelTypeface = options.FontLoader("1");
-                var labelFont = new SKFont(labelTypeface, labelFontSize);
-                labelFont.GetFontMetrics(out var labelFontMetrics);
-                int labelHeight = barcode.PrintInterpretationLine ? (int)Math.Ceiling((labelFontMetrics.Bottom - labelFontMetrics.Top) + labelFontMetrics.Descent) : 0;
+                var labelFont = new SKFont(labelTypeface, labelFontSize).ToSystemDrawingFont();
+                int labelHeight = barcode.PrintInterpretationLine ? labelFont.Height : 0;
 
                 var barcodeElement = new Barcode {
                     BarWidth = barcode.ModuleWidth,
@@ -45,7 +43,7 @@ namespace BinaryKits.Zpl.Viewer.ElementDrawers
                     Height = barcode.Height + labelHeight,
                     IncludeLabel = barcode.PrintInterpretationLine,
                     LabelPosition = barcode.PrintInterpretationLineAboveCode ? LabelPositions.TOPCENTER : LabelPositions.BOTTOMCENTER,
-                    LabelFont = labelFont.ToSystemDrawingFont()
+                    LabelFont = labelFont
                 };
 
                 using var image = barcodeElement.Encode(TYPE.CODE128B, barcode.Content);

--- a/src/BinaryKits.Zpl.Viewer/Helpers/FontHelper.cs
+++ b/src/BinaryKits.Zpl.Viewer/Helpers/FontHelper.cs
@@ -1,0 +1,24 @@
+﻿using SkiaSharp;
+using System;
+using System.Drawing;
+using System.Drawing.Text;
+using System.Runtime.InteropServices;
+
+namespace BinaryKits.Zpl.Viewer.Helpers {
+    public static class FontHelper {
+
+        public static Font ToSystemDrawingFont(this SKFont skFont) {
+            using(var fontCollection = new PrivateFontCollection())
+            using(var fontStream = skFont.Typeface.OpenStream()) {
+                byte[] fontBytes = (byte[])Array.CreateInstance(typeof(byte), fontStream.Length);
+                fontStream.Read(fontBytes, fontBytes.Length);
+                IntPtr fontPtr = Marshal.AllocCoTaskMem(fontBytes.Length);
+                Marshal.Copy(fontBytes, 0, fontPtr, fontBytes.Length);
+                fontCollection.AddMemoryFont(fontPtr, fontBytes.Length);
+                Marshal.FreeCoTaskMem(fontPtr);
+                return new Font(fontCollection.Families[0], skFont.Size);
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
Addresses issue #119 

Set properties in the `BarcodeLib.Barcode` to correctly render the interpretation line, if present. A `FontHelper` class is added to conveniently convert from `SkiaSharp.SKFont` to `System.Drawing.Font`, as needed by `BarcodeLib`. The label font is chosen to be font 1 from the given `DrawerOptions`.