### PR TITLE
Improved rendering of Barcode128 labels, modes

### DIFF
--- a/src/BinaryKits.Zpl.Label/Elements/ZplBarcode128.cs
+++ b/src/BinaryKits.Zpl.Label/Elements/ZplBarcode128.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace BinaryKits.Zpl.Label.Elements
 {
@@ -7,6 +7,9 @@ namespace BinaryKits.Zpl.Label.Elements
     /// </summary>
     public class ZplBarcode128 : ZplBarcode
     {
+
+        public string Mode { get; set; }
+
         /// <summary>
         /// Code 128 Barcode
         /// </summary>
@@ -20,6 +23,7 @@ namespace BinaryKits.Zpl.Label.Elements
         /// <param name="printInterpretationLine"></param>
         /// <param name="printInterpretationLineAboveCode"></param>
         /// <param name="bottomToTop"></param>
+        /// <param name="mode"></param>
         public ZplBarcode128(
             string content,
             int positionX,
@@ -30,7 +34,8 @@ namespace BinaryKits.Zpl.Label.Elements
             FieldOrientation fieldOrientation = FieldOrientation.Normal,
             bool printInterpretationLine = true,
             bool printInterpretationLineAboveCode = false,
-            bool bottomToTop = false)
+            bool bottomToTop = false,
+            string mode = "N")
             : base(content,
                   positionX,
                   positionY,
@@ -42,6 +47,7 @@ namespace BinaryKits.Zpl.Label.Elements
                   printInterpretationLineAboveCode,
                   bottomToTop)
         {
+            this.Mode = mode;
         }
 
         ///<inheritdoc/>

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/Code128BarcodeZplCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/Code128BarcodeZplCommandAnalyzer.cs
@@ -1,4 +1,4 @@
-﻿using BinaryKits.Zpl.Label.Elements;
+using BinaryKits.Zpl.Label.Elements;
 using BinaryKits.Zpl.Viewer.Models;
 
 namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
@@ -21,11 +21,14 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
 
             if (zplDataParts.Length > 1)
             {
-                _ = int.TryParse(zplDataParts[1], out height);
+                if(!string.IsNullOrEmpty(zplDataParts[1]))
+                {
+                    _ = int.TryParse(zplDataParts[1], out height);
+                }
             }
             if (zplDataParts.Length > 2)
             {
-                printInterpretationLine = !this.ConvertBoolean(zplDataParts[2]);
+                printInterpretationLine = this.ConvertBoolean(zplDataParts[2], "Y");
             }
             if (zplDataParts.Length > 3)
             {

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/FieldDataZplCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/FieldDataZplCommandAnalyzer.cs
@@ -1,4 +1,4 @@
-﻿using BinaryKits.Zpl.Label.Elements;
+using BinaryKits.Zpl.Label.Elements;
 using BinaryKits.Zpl.Viewer.Models;
 
 namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
@@ -43,7 +43,7 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
                 }
                 if (this.VirtualPrinter.NextElementFieldData is Code128BarcodeFieldData code128)
                 {
-                    return new ZplBarcode128(text, x, y, code128.Height, moduleWidth, wideBarToNarrowBarWidthRatio, code128.FieldOrientation, code128.PrintInterpretationLine, code128.PrintInterpretationLineAboveCode, bottomToTop);
+                    return new ZplBarcode128(text, x, y, code128.Height, moduleWidth, wideBarToNarrowBarWidthRatio, code128.FieldOrientation, code128.PrintInterpretationLine, code128.PrintInterpretationLineAboveCode, bottomToTop, code128.Mode);
                 }
 
                 if (this.VirtualPrinter.NextElementFieldData is CodeEAN13BarcodeFieldData codeEAN13)

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/ZplCommandAnalyzerBase.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/ZplCommandAnalyzerBase.cs
@@ -1,4 +1,4 @@
-﻿using BinaryKits.Zpl.Label;
+using BinaryKits.Zpl.Label;
 using BinaryKits.Zpl.Label.Elements;
 
 namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
@@ -44,14 +44,9 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
             return FieldOrientation.Normal;
         }
 
-        protected bool ConvertBoolean(string yesOrNo)
+        protected bool ConvertBoolean(string yesOrNo, string defaultValue = "N")
         {
-            if (yesOrNo == "Y")
-            {
-                return true;
-            }
-
-            return false;
+            return (!string.IsNullOrEmpty(yesOrNo) ? yesOrNo : defaultValue) == "Y";
         }
 
         protected int IndexOfNthCharacter(string input, int occurranceToFind, char charToFind)

--- a/src/BinaryKits.Zpl.Viewer/ElementDrawers/Barcode128ElementDrawer.cs
+++ b/src/BinaryKits.Zpl.Viewer/ElementDrawers/Barcode128ElementDrawer.cs
@@ -1,11 +1,29 @@
-﻿using BarcodeLib;
+using BarcodeLib;
 using BinaryKits.Zpl.Label.Elements;
+using BinaryKits.Zpl.Viewer.Helpers;
+using SkiaSharp;
+using System.Collections.Generic;
 using System.Drawing;
+using System.Text.RegularExpressions;
 
 namespace BinaryKits.Zpl.Viewer.ElementDrawers
 {
     public class Barcode128ElementDrawer : BarcodeDrawerBase
     {
+
+        /// <summary>
+        /// Start sequence lookups.
+        /// <see cref="https://supportcommunity.zebra.com/s/article/Creating-GS1-Barcodes-with-Zebra-Printers-for-Data-Matrix-and-Code-128-using-ZPL"/>
+        /// </summary>
+        private static readonly Dictionary<string, TYPE> startCodeMap = new Dictionary<string, TYPE>()
+        {
+            { ">9", TYPE.CODE128A },
+            { ">:", TYPE.CODE128B },
+            { ">;", TYPE.CODE128C }
+        };
+
+        private static readonly Regex startCodeRegex = new Regex(@"^(>[9:;])(.+)$", RegexOptions.Compiled);
+
         ///<inheritdoc/>
         public override bool CanDraw(ZplElementBase element)
         {
@@ -15,9 +33,35 @@ namespace BinaryKits.Zpl.Viewer.ElementDrawers
         ///<inheritdoc/>
         public override void Draw(ZplElementBase element)
         {
+            Draw(element, new DrawerOptions());
+        }
+
+        ///<inheritdoc/>
+        public override void Draw(ZplElementBase element, DrawerOptions options)
+        {
             if (element is ZplBarcode128 barcode)
             {
                 var barcodeType = TYPE.CODE128B;
+                string content = barcode.Content;
+                if(string.IsNullOrEmpty(barcode.Mode) || barcode.Mode == "N")
+                {
+                    Match startCodeMatch = startCodeRegex.Match(content);
+                    if(startCodeMatch.Success)
+                    {
+                        barcodeType = startCodeMap[startCodeMatch.Groups[1].Value];
+                        content = startCodeMatch.Groups[2].Value;
+                    }
+                    // TODO: support escapes within a barcode, not only start sequences
+                }
+                else if(barcode.Mode == "A")
+                {
+                    barcodeType = TYPE.CODE128; // dynamic
+                }
+                else
+                {
+                    // TODO: support for mode D/U
+                }
+
                 float x = barcode.PositionX;
                 float y = barcode.PositionY;
 
@@ -26,21 +70,28 @@ namespace BinaryKits.Zpl.Viewer.ElementDrawers
                     y -= barcode.Height;
                 }
 
+                float labelFontSize = barcode.ModuleWidth * 7.25f;
+                var labelTypeFace = options.FontLoader("1");
+                var labelFont = new SKFont(labelTypeFace, labelFontSize).ToSystemDrawingFont();
+                int labelHeight = barcode.PrintInterpretationLine ? labelFont.Height : 0;
+
                 var barcodeElement = new Barcode
                 {
                     BarWidth = barcode.ModuleWidth,
                     BackColor = Color.Transparent,
-                    Height = barcode.Height
+                    Height = barcode.Height + labelHeight,
+                    IncludeLabel = barcode.PrintInterpretationLine,
+                    LabelPosition = barcode.PrintInterpretationLineAboveCode ? LabelPositions.TOPCENTER : LabelPositions.BOTTOMCENTER,
+                    LabelFont = labelFont
                 };
 
-                Image? image;
-         
-                if( barcode.Content.Length >= 12 ){
-                    barcodeType = TYPE.CODE128;
+                if(barcode.PrintInterpretationLineAboveCode)
+                {
+                    y -= labelHeight;
                 }
-                
-                image = barcodeElement.Encode(barcodeType, barcode.Content);
-                this.DrawBarcode(this.GetImageData(image), barcode.Height, image.Width, barcode.FieldOrigin != null, x, y, barcode.FieldOrientation);
+
+                Image image = barcodeElement.Encode(barcodeType, content);
+                this.DrawBarcode(this.GetImageData(image), barcode.Height + labelHeight, image.Width, barcode.FieldOrigin != null, x, y, barcode.FieldOrientation);
             }
         }
     }

--- a/src/BinaryKits.Zpl.Viewer/Helpers/FontHelper.cs
+++ b/src/BinaryKits.Zpl.Viewer/Helpers/FontHelper.cs
@@ -1,0 +1,28 @@
+using SkiaSharp;
+using System;
+using System.Drawing;
+using System.Drawing.Text;
+using System.Runtime.InteropServices;
+
+namespace BinaryKits.Zpl.Viewer.Helpers
+{
+    public static class FontHelper
+    {
+
+        public static Font ToSystemDrawingFont(this SKFont skFont)
+        {
+            using(var fontCollection = new PrivateFontCollection())
+            using(var fontStream = skFont.Typeface.OpenStream())
+            {
+                byte[] fontBytes = (byte[])Array.CreateInstance(typeof(byte), fontStream.Length);
+                fontStream.Read(fontBytes, fontBytes.Length);
+                IntPtr fontPtr = Marshal.AllocCoTaskMem(fontBytes.Length);
+                Marshal.Copy(fontBytes, 0, fontPtr, fontBytes.Length);
+                fontCollection.AddMemoryFont(fontPtr, fontBytes.Length);
+                Marshal.FreeCoTaskMem(fontPtr);
+                return new Font(fontCollection.Families[0], skFont.Size);
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
- Adds the `Mode` property to the `ZplBarcode128` class.
- Correctly parses empty fields by adding an optional default value to the `ConvertBoolean` method.
- Displays the presentation line either below or above the barcode, as specified by the data fields.
- Adds a FontHelper method to convert from `SkiaSharp.SKFont` to `System.Drawing.Font`, as required by BarcodeLib.
- Adds support for mode `A`, and partial support for mode `N`.

Known issues:
---
- No support for modes `D` or `U`.
- In mode `N` only start sequences are handled. Further escape sequences within the code are not correctly handled.

Tests:
---
Long numeric barcode, mode `N`:
```zpl
^XA
^FO60,1060^BY3,2^BCN,200,Y,Y,N,N^FD1013486130441141878600786403467495^FS
^XZ
```
Correct result: Type B is selected, barcode overflows container.

---
Long numeric barcode, mode `A`:
```zpl
^XA
^FO60,1060^BY3,2^BCN,200,Y,Y,N,A^FD1013486130441141878600786403467495^FS
^XZ
```
Correct result: Type C is selected, barcode fits container.

---
Long numeric barcode, mode `N` with Type C start sequence (`>;`):
```zpl
^XA
^FO60,1060^BY3,2^BCN,200,Y,Y,N,N^FD>;1013486130441141878600786403467495^FS
^XZ
```
Correct result: Type C is selected, barcode fits container.

---
Long numeric barcode, mode `A` with Type C start sequence (`>;`):
```zpl
^XA
^FO60,1060^BY3,2^BCN,200,Y,Y,N,A^FD>;1013486130441141878600786403467495^FS
^XZ
```
Correct result: The start sequence is part of the barcode. Type begins as B, and switches to C after the first two characters.

---
Alphanumeric barcode, blank line flag, above flag `N`:
```zpl
^XA
^FO100,750^BY3,2,100^BCN,,,N^FDTEST0123456789^FS
^XZ
```
Correct result: Presentation line is displayed below.

---
Alphanumeric barcode, blank line flag, above flag `Y`:
```zpl
^XA
^FO100,750^BY3,2,100^BCN,,,Y^FDTEST0123456789^FS
^XZ
```
Correct result: Presentation line is displayed above, barcode location is the same as the previous test.

---
Alphanumeric barcode, line flag `N`, blank above flag:
```zpl
^XA
^FO100,750^BY3,2,100^BCN,,N,^FDTEST0123456789^FS
^XZ
```
Correct result: No presentation line is displayed.

---
Alphanumeric barcode, line flag `Y`, blank above flag:
```zpl
^XA
^FO100,750^BY3,2,100^BCN,,Y,^FDTEST0123456789^FS
^XZ
```
Correct result: Presentation line is displayed below.