### PR TITLE
Add Labelary overlay to webapi

### DIFF
--- a/src/BinaryKits.Zpl.Viewer.WebApi/BinaryKits.Zpl.Viewer.WebApi.csproj
+++ b/src/BinaryKits.Zpl.Viewer.WebApi/BinaryKits.Zpl.Viewer.WebApi.csproj
@@ -10,6 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\BinaryKits.Zpl.Labelary\BinaryKits.Zpl.Labelary.csproj" />
     <ProjectReference Include="..\BinaryKits.Zpl.Viewer\BinaryKits.Zpl.Viewer.csproj" />
   </ItemGroup>
 

--- a/src/BinaryKits.Zpl.Viewer.WebApi/Controllers/ViewerController.cs
+++ b/src/BinaryKits.Zpl.Viewer.WebApi/Controllers/ViewerController.cs
@@ -1,9 +1,15 @@
-﻿using BinaryKits.Zpl.Viewer.WebApi.Models;
+﻿using BinaryKits.Zpl.Label;
+using BinaryKits.Zpl.Labelary;
+using BinaryKits.Zpl.Viewer.WebApi.Models;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.IO;
+using System.Threading.Tasks;
 
 namespace BinaryKits.Zpl.Viewer.WebApi.Controllers
 {
@@ -19,11 +25,11 @@ namespace BinaryKits.Zpl.Viewer.WebApi.Controllers
         }
 
         [HttpPost]
-        public ActionResult<RenderResponseDto> Render(RenderRequestDto request)
+        public async Task<ActionResult<RenderResponseDto>> Render(RenderRequestDto request)
         {
             try
             {
-                return RenderZpl(request);
+                return await RenderZpl(request);
             }
             catch (Exception ex)
             {
@@ -31,7 +37,7 @@ namespace BinaryKits.Zpl.Viewer.WebApi.Controllers
             }
         }
 
-        private ActionResult<RenderResponseDto> RenderZpl(RenderRequestDto request)
+        private async Task<ActionResult<RenderResponseDto>> RenderZpl(RenderRequestDto request)
         {
             IPrinterStorage printerStorage = new PrinterStorage();
             var drawer = new ZplElementDrawer(printerStorage);
@@ -39,15 +45,31 @@ namespace BinaryKits.Zpl.Viewer.WebApi.Controllers
             var analyzer = new ZplAnalyzer(printerStorage);
             var analyzeInfo = analyzer.Analyze(request.ZplData);
 
+            var labelaryClient = new LabelaryClient();
             var labels = new List<RenderLabelDto>();
             foreach (var labelInfo in analyzeInfo.LabelInfos)
             {
                 var imageData = drawer.Draw(labelInfo.ZplElements, request.LabelWidth, request.LabelHeight, request.PrintDensityDpmm);
-                var label = new RenderLabelDto
+
+                if (request.ShowLabelaryOverlay)
                 {
-                    ImageBase64 = Convert.ToBase64String(imageData)
-                };
-                labels.Add(label);
+                    var zpl = analyzeInfo.LabelInfos.Length > 1 ? new ZplEngine(labelInfo.ZplElements).ToZplString(new ZplRenderOptions() { }) : request.ZplData;
+                    var labelaryImage = await labelaryClient.GetPreviewAsync(zpl, GetLabelaryDensity(request.PrintDensityDpmm), new LabelSize(request.LabelWidth, request.LabelHeight, Measure.Millimeter));
+
+                    using (var bmpLabelary = LoadBitmap(labelaryImage))
+                    using (var bmpDrawer = LoadBitmap(imageData))
+                    {
+                        GenerateOverlay(bmpDrawer, bmpLabelary);
+                        labels.Add(new RenderLabelDto()
+                        {
+                            ImageBase64 = Convert.ToBase64String(SaveToByteArray(bmpDrawer, ImageFormat.Png))
+                        });
+                    }
+                }
+                else
+                {
+                    labels.Add(new RenderLabelDto() { ImageBase64 = Convert.ToBase64String(imageData) });
+                }
             }
 
             var response = new RenderResponseDto
@@ -57,6 +79,76 @@ namespace BinaryKits.Zpl.Viewer.WebApi.Controllers
             };
 
             return this.StatusCode(StatusCodes.Status200OK, response);
+        }
+
+        private static Bitmap LoadBitmap(byte[] bytes)
+        {
+            using (var ms = new MemoryStream(bytes))
+            return new Bitmap(ms);                
+        }
+
+        private static PrintDensity GetLabelaryDensity(int density)
+        {
+            switch (density)
+            {
+                case 6:
+                    return PrintDensity.PD6dpmm;
+                case 8:
+                    return PrintDensity.PD8dpmm;
+                case 12:
+                    return PrintDensity.PD12dpmm;
+                case 24:
+                    return PrintDensity.PD24dpmm;
+                default:
+                    throw new NotSupportedException($"Print density '{density}' is not supported by labelary!");
+            }
+        }
+
+        private static void GenerateOverlay(Bitmap bitmapBackground, Bitmap bitmapOverlay)
+        {
+            ToBlackWhite(bitmapOverlay);
+            var colorMaps = new ColorMap[2];
+            colorMaps[0] = new ColorMap() { OldColor = Color.White, NewColor = Color.Transparent };
+
+            colorMaps[1] = new ColorMap() { NewColor = Color.FromArgb(128, Color.Red), OldColor = Color.Black };
+
+            var imageAttr = new ImageAttributes();
+            imageAttr.SetRemapTable(colorMaps);
+
+            using(var g = Graphics.FromImage(bitmapBackground))
+            {
+                g.DrawImage(bitmapOverlay, new Rectangle(0, 0, bitmapOverlay.Width, bitmapOverlay.Height), 0, 0, bitmapOverlay.Width, bitmapOverlay.Height, GraphicsUnit.Pixel, imageAttr);
+            }
+        }
+
+        private static byte[] SaveToByteArray(Bitmap bitmap, ImageFormat imageFormat)
+        {
+            using (var msSave = new MemoryStream())
+            {
+            bitmap.Save(msSave, imageFormat);
+            return msSave.ToArray();
+            }
+        }
+
+        private static void ToBlackWhite(Bitmap image)
+        {
+            using(var copyImg = new Bitmap(image))
+            using (Graphics gr = Graphics.FromImage(image)) // SourceImage is a Bitmap object
+            {
+                var gray_matrix = new float[][] {
+                    new float[] { 0.299f, 0.299f, 0.299f, 0, 0 },
+                    new float[] { 0.587f, 0.587f, 0.587f, 0, 0 },
+                    new float[] { 0.114f, 0.114f, 0.114f, 0, 0 },
+                    new float[] { 0,      0,      0,      1, 0 },
+                    new float[] { 0,      0,      0,      0, 1 }
+                };
+
+                var ia = new ImageAttributes();
+                ia.SetColorMatrix(new ColorMatrix(gray_matrix));
+                ia.SetThreshold(0.8f); // Change this threshold as needed
+                var rc = new Rectangle(0, 0, image.Width, image.Height);
+                gr.DrawImage(copyImg, rc, 0, 0, image.Width, image.Height, GraphicsUnit.Pixel, ia);
+            }
         }
     }
 }

--- a/src/BinaryKits.Zpl.Viewer.WebApi/Models/RenderRequestDto.cs
+++ b/src/BinaryKits.Zpl.Viewer.WebApi/Models/RenderRequestDto.cs
@@ -18,5 +18,10 @@
         /// Dots per Millimeter
         /// </summary>
         public int PrintDensityDpmm { get; set; } = 8;
+
+        /// <summary>
+        /// Red Labelary overlay
+        /// </summary>
+        public bool ShowLabelaryOverlay { get; set; } = false;
     }
 }

--- a/src/BinaryKits.Zpl.Viewer.WebApi/wwwroot/index.html
+++ b/src/BinaryKits.Zpl.Viewer.WebApi/wwwroot/index.html
@@ -29,7 +29,7 @@
             <div class="col-4">
                 <textarea class="form-control" v-model="zplData" rows="20" cols="100"></textarea>
                 <div class="mt-1 mb-1">
-                    Labelformat: 
+                    Labelformat:
                     <select v-model="selectedLabelFormatIndex" @change="labelFormatChange">
                         <option v-for="(labelFormat, index) in labelFormats" :key="index" :value="index">{{ labelFormat.width }} mm x {{ labelFormat.height }} mm</option>
                     </select>
@@ -37,6 +37,7 @@
                     <input type="text" v-model.number="labelWidth" style="width: 50px" /> mm ({{labelWidthInch}} inches)
                     <input type="text" v-model.number="labelHeight" style="width: 50px" /> mm ({{labelHeightInch}} inches)
                     <input type="text" v-model.number="printDensityDpmm" style="width: 40px" /> dpmm ({{dpi}} dpi)<br />
+                    <input type="checkbox" v-model="showLabelaryOverlay" /> Labelary Overlay<br />
                 </div>
                 <button type="button" class="btn btn-primary" @click="render">Render</button>
                 <hr />
@@ -103,7 +104,8 @@
                             width: 54,
                             height: 86
                         }
-                    ]
+                    ],
+                    showLabelaryOverlay: false
                 }
             },
             computed: {
@@ -148,7 +150,8 @@
                             zplData: this.zplData,
                             printDensityDpmm: this.printDensityDpmm,
                             labelWidth: this.labelWidth,
-                            labelHeight: this.labelHeight
+                            labelHeight: this.labelHeight,
+                            showLabelaryOverlay: this.showLabelaryOverlay
                         }
                         const response = await axios.post('api/v1/viewer', payload)
                         this.renderResponse = response.data


### PR DESCRIPTION
This PR offers the possibility to superimpose the image of Labelary on the image of the viewer. This allows you to quickly see how accurate the new viewer is.

![grafik](https://user-images.githubusercontent.com/20139038/183646448-b5520175-2fdc-4f45-ac4a-d7e197207b16.png)
