### PR TITLE
Rework TextField and FieldBlock

### DIFF
--- a/src/BinaryKits.Zpl.Label/Elements/ZplFieldBlock.cs
+++ b/src/BinaryKits.Zpl.Label/Elements/ZplFieldBlock.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 namespace BinaryKits.Zpl.Label.Elements
@@ -29,8 +29,9 @@ namespace BinaryKits.Zpl.Label.Elements
             int hangingIndent = 0,
             NewLineConversionMethod newLineConversion = NewLineConversionMethod.ToZplNewLine,
             bool useHexadecimalIndicator = true,
-            bool reversePrint = false)
-            : base(text, positionX, positionY, font, newLineConversion, useHexadecimalIndicator, reversePrint)
+            bool reversePrint = false,
+            bool bottomToTop = false)
+            : base(text, positionX, positionY, font, newLineConversion, useHexadecimalIndicator, reversePrint, bottomToTop)
         {
             TextJustification = textJustification;
             Width = width;

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/FieldDataZplCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/FieldDataZplCommandAnalyzer.cs
@@ -84,8 +84,9 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
                 var maxLineCount = this.VirtualPrinter.NextElementFieldBlock.MaximumNumberOfLinesInTextBlock;
                 var textJustification = this.VirtualPrinter.NextElementFieldBlock.TextJustification;
                 var lineSpace = this.VirtualPrinter.NextElementFieldBlock.AddOrDeleteSpaceBetweenLines;
+                var hangingIndent = this.VirtualPrinter.NextElementFieldBlock.HangingIndentOfTheSecondAndRemainingLines;
 
-                return new ZplFieldBlock(text, x, y, width, font, maxLineCount, lineSpace, textJustification, reversePrint : reversePrint);
+                return new ZplFieldBlock(text, x, y, width, font, maxLineCount, lineSpace, textJustification, hangingIndent, reversePrint : reversePrint, bottomToTop: bottomToTop);
             }
 
             return new ZplTextField(text, x, y, font, reversePrint: reversePrint, bottomToTop: bottomToTop);

--- a/src/BinaryKits.Zpl.Viewer/ElementDrawers/Barcode128ElementDrawer.cs
+++ b/src/BinaryKits.Zpl.Viewer/ElementDrawers/Barcode128ElementDrawer.cs
@@ -14,7 +14,7 @@ namespace BinaryKits.Zpl.Viewer.ElementDrawers
 
         /// <summary>
         /// Start sequence lookups.
-        /// <see cref="https://supportcommunity.zebra.com/s/article/Creating-GS1-Barcodes-with-Zebra-Printers-for-Data-Matrix-and-Code-128-using-ZPL"/>
+        /// <see href="https://supportcommunity.zebra.com/s/article/Creating-GS1-Barcodes-with-Zebra-Printers-for-Data-Matrix-and-Code-128-using-ZPL"/>
         /// </summary>
         private static readonly Dictionary<string, TYPE> startCodeMap = new Dictionary<string, TYPE>()
         {
@@ -100,7 +100,7 @@ namespace BinaryKits.Zpl.Viewer.ElementDrawers
                 }
 
                 float labelFontSize = barcode.ModuleWidth * 7.25f;
-                var labelTypeFace = options.FontLoader("1");
+                var labelTypeFace = options.FontLoader("A");
                 var labelFont = new SKFont(labelTypeFace, labelFontSize).ToSystemDrawingFont();
                 int labelHeight = barcode.PrintInterpretationLine ? labelFont.Height : 0;
 

--- a/src/BinaryKits.Zpl.Viewer/ElementDrawers/FieldBlockElementDrawer.cs
+++ b/src/BinaryKits.Zpl.Viewer/ElementDrawers/FieldBlockElementDrawer.cs
@@ -1,9 +1,11 @@
-﻿using BinaryKits.Zpl.Label;
+using BinaryKits.Zpl.Label;
 using BinaryKits.Zpl.Label.Elements;
 using BinaryKits.Zpl.Viewer.Helpers;
 using SkiaSharp;
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Text;
 
 namespace BinaryKits.Zpl.Viewer.ElementDrawers
 {
@@ -28,156 +30,190 @@ namespace BinaryKits.Zpl.Viewer.ElementDrawers
         ///<inheritdoc/>
         public override void Draw(ZplElementBase element)
         {
+            Draw(element, new DrawerOptions());
+        }
+
+        ///<inheritdoc/>
+        public override void Draw(ZplElementBase element, DrawerOptions options)
+        {
             if (element is ZplFieldBlock fieldBlock)
             {
-                float x = fieldBlock.PositionX;
-                float y = fieldBlock.PositionY;
-
                 var font = fieldBlock.Font;
 
                 float fontSize = font.FontHeight > 0 ? font.FontHeight : font.FontWidth;
                 var scaleX = 0.95f;
                 if (font.FontWidth != 0 && font.FontWidth != fontSize)
                 {
-                    scaleX = (float)font.FontWidth / fontSize;
+                    scaleX *= (float)font.FontWidth / fontSize;
                 }
 
                 fontSize *= 0.95f;
 
-                var typeface = SKTypeface.Default;
-                if (font.FontName == "0")
+                var typeface = options.FontLoader(font.FontName);
+                var text = fieldBlock.Text;
+                if (fieldBlock.UseHexadecimalIndicator)
                 {
-                    //typeface = SKTypeface.FromFile(@"swiss-721-black-bt.ttf");
-                    typeface = SKTypeface.FromFamilyName("Arial", SKFontStyleWeight.Bold, SKFontStyleWidth.Normal, SKFontStyleSlant.Upright);
+                    text = text.ReplaceHexEscapes();
+                }
+                text = text.Replace("-", " \u2013 ");
+
+                var skFont = new SKFont(typeface, fontSize, scaleX);
+                using var skPaint = new SKPaint(skFont);
+                var textBoundBaseline = new SKRect();
+                skPaint.MeasureText("X", ref textBoundBaseline);
+
+                float x = fieldBlock.PositionX;
+                float y = fieldBlock.PositionY + textBoundBaseline.Height;
+
+                var textLines = WordWrap(text, skFont, fieldBlock.Width);
+                var hangingIndent = 0;
+                var lineHeight = fontSize + fieldBlock.LineSpace;
+
+                // actual ZPL printer does not include trailing line spacing in total height
+                var totalHeight = lineHeight * fieldBlock.MaxLineCount - fieldBlock.LineSpace;
+                // labelary
+                //var totalHeight = lineHeight * fieldBlock.MaxLineCount;
+
+                if (fieldBlock.FieldTypeset != null)
+                {
+                    totalHeight = lineHeight * (fieldBlock.MaxLineCount-1) + textBoundBaseline.Height;
+                    y -= totalHeight;
                 }
 
-                var textLines = getLines(fieldBlock, typeface, fontSize, scaleX);
-
-                foreach (var textLine in textLines)
+                using (new SKAutoCanvasRestore(this._skCanvas))
                 {
-                    using var skPaint = new SKPaint();
-                    skPaint.Color = SKColors.Black;
-                    skPaint.Typeface = typeface;
-                    skPaint.TextSize = fontSize;
-                    skPaint.TextScaleX = scaleX;
-                    //Reset the X point for the next row
-                    x = fieldBlock.PositionX;
+                    SKMatrix matrix = SKMatrix.Empty;
 
-                    var textBounds = new SKRect();
-                    var textBoundBaseline = new SKRect();
-                    skPaint.MeasureText(new string('A', fieldBlock.Text.Length), ref textBoundBaseline);
-                    skPaint.MeasureText(textLine, ref textBounds);
-                    textBoundBaseline.Bottom = 1;
-
-                    switch (fieldBlock.TextJustification)
+                    if (fieldBlock.FieldOrigin != null)
                     {
-                        case TextJustification.Center:
-                            var diff = fieldBlock.Width - textBounds.Width;
-                            x += diff / 2;
-                            break;
-                        case TextJustification.Right:
-                            diff = fieldBlock.Width - textBounds.Width;
-                            x += diff;
-                            break;
-                        case TextJustification.Left:
-                        case TextJustification.Justified:
-                        default:
-                            break;
+                        switch (fieldBlock.Font.FieldOrientation)
+                        {
+                            case FieldOrientation.Rotated90:
+                                matrix = SKMatrix.CreateRotationDegrees(90, fieldBlock.PositionX + totalHeight / 2, fieldBlock.PositionY + totalHeight / 2);
+                                break;
+                            case FieldOrientation.Rotated180:
+                                matrix = SKMatrix.CreateRotationDegrees(180, fieldBlock.PositionX + fieldBlock.Width / 2, fieldBlock.PositionY + totalHeight / 2);
+                                break;
+                            case FieldOrientation.Rotated270:
+                                matrix = SKMatrix.CreateRotationDegrees(270, fieldBlock.PositionX + fieldBlock.Width / 2, fieldBlock.PositionY + fieldBlock.Width / 2);
+                                break;
+                            case FieldOrientation.Normal:
+                                break;
+                        }
+                    }
+                    else
+                    {
+                        switch (fieldBlock.Font.FieldOrientation)
+                        {
+                            case FieldOrientation.Rotated90:
+                                matrix = SKMatrix.CreateRotationDegrees(90, fieldBlock.PositionX, fieldBlock.PositionY);
+                                break;
+                            case FieldOrientation.Rotated180:
+                                matrix = SKMatrix.CreateRotationDegrees(180, fieldBlock.PositionX, fieldBlock.PositionY);
+                                break;
+                            case FieldOrientation.Rotated270:
+                                matrix = SKMatrix.CreateRotationDegrees(270, fieldBlock.PositionX, fieldBlock.PositionY);
+                                break;
+                            case FieldOrientation.Normal:
+                                break;
+                        }
                     }
 
-                    if (fieldBlock.FieldTypeset != null)
+                    if (matrix != SKMatrix.Empty)
                     {
-                        y -= textBounds.Height;
+                        this._skCanvas.SetMatrix(matrix);
                     }
 
-                    using (new SKAutoCanvasRestore(this._skCanvas))
+                    foreach (var textLine in textLines)
                     {
-                        SKMatrix matrix = SKMatrix.Empty;
+                        x = fieldBlock.PositionX + hangingIndent;
 
-                        if (fieldBlock.FieldOrigin != null)
+                        var textBounds = new SKRect();
+                        skPaint.MeasureText(textLine, ref textBounds);
+                        var diff = fieldBlock.Width - textBounds.Width;
+
+                        switch (fieldBlock.TextJustification)
                         {
-                            switch (fieldBlock.Font.FieldOrientation)
-                            {
-                                case FieldOrientation.Rotated90:
-                                    matrix = SKMatrix.CreateRotationDegrees(90, x, y);
-                                    y -= font.FontHeight - textBoundBaseline.Height;
-                                    break;
-                                case FieldOrientation.Rotated180:
-                                    matrix = SKMatrix.CreateRotationDegrees(180, x, y);
-                                    x -= textBounds.Width;
-                                    y -= font.FontHeight - textBoundBaseline.Height;
-                                    break;
-                                case FieldOrientation.Rotated270:
-                                    matrix = SKMatrix.CreateRotationDegrees(270, x, y);
-                                    x -= textBounds.Width;
-                                    y += textBoundBaseline.Height;
-                                    break;
-                                case FieldOrientation.Normal:
-                                    y += textBoundBaseline.Height;
-                                    break;
-                            }
-                        }
-                        else
-                        {
-                            switch (fieldBlock.Font.FieldOrientation)
-                            {
-                                case FieldOrientation.Rotated90:
-                                    matrix = SKMatrix.CreateRotationDegrees(90, x, y);
-                                    x += textBoundBaseline.Height;
-                                    break;
-                                case FieldOrientation.Rotated180:
-                                    matrix = SKMatrix.CreateRotationDegrees(180, x, y);
-                                    y -= textBoundBaseline.Height;
-                                    break;
-                                case FieldOrientation.Rotated270:
-                                    matrix = SKMatrix.CreateRotationDegrees(270, x, y);
-                                    x -= textBoundBaseline.Height;
-                                    break;
-                                case FieldOrientation.Normal:
-                                    y += textBoundBaseline.Height;
-                                    break;
-                            }
+                            case TextJustification.Center:
+                                x += diff / 2 - textBounds.Left;
+                                break;
+                            case TextJustification.Right:
+                                x += diff - textBounds.Left * 2;
+                                hangingIndent = -fieldBlock.HangingIndent;
+                                break;
+                            case TextJustification.Left:
+                            case TextJustification.Justified:
+                            default:
+                                hangingIndent = fieldBlock.HangingIndent;
+                                break;
                         }
 
-                        if (matrix != SKMatrix.Empty)
-                        {
-                            this._skCanvas.SetMatrix(matrix);
-                        }
-
-                        this._skCanvas.DrawText(textLine, x, y, new SKFont(typeface, fontSize, scaleX, 0), skPaint);
+                        this._skCanvas.DrawText(textLine, x, y, skFont, skPaint);
+                        y += lineHeight;
                     }
                 }
             }
         }
-        
-        private List<String> getLines(ZplFieldBlock fieldBlock , SKTypeface? typeface, float fontSize, float scaleX){
-            var tempPaint = new SKPaint();
-            tempPaint.Typeface = typeface;
-            tempPaint.TextSize = fontSize;
-            tempPaint.TextScaleX = scaleX;
-            
-            var textLines = new List<String>();
-            var totalLines = (int)Math.Ceiling(tempPaint.MeasureText(fieldBlock.Text) / fieldBlock.Width);
 
-            if(totalLines > 1 ){
-                var totalWidth = (int)tempPaint.MeasureText(fieldBlock.Text);
-                var charactersPerLine = tempPaint.BreakText(fieldBlock.Text, 600);
-                var totalChars = 0;
+        private IEnumerable<string> WordWrap(string text, SKFont font, int maxWidth)
+        {
+            using var tmpPaint = new SKPaint(font);
+            var spaceWidth = tmpPaint.MeasureText(" ");
+            var lines = new List<string>();
 
-                for( int i = 0; i < totalLines; i++){
-                    if( i == totalLines - 1){
-                        textLines.Add(fieldBlock.Text.Substring(i * (int)charactersPerLine, fieldBlock.Text.Length - totalChars).ReplaceSpecialChars());
-                    } else { 
-                        textLines.Add(fieldBlock.Text.Substring(i * (int)charactersPerLine, (int)charactersPerLine).ReplaceSpecialChars());
+            var words = new Stack<string>(text.Split(new[] { ' ' }, StringSplitOptions.None).Reverse());
+            var line = new StringBuilder();
+            float width = 0;
+            while(words.Any())
+            {
+                var word = words.Pop();
+                if (word.Contains(@"\&"))
+                {
+                    var subwords = word.Split(new[] { @"\&" }, 2, StringSplitOptions.None);
+                    word = subwords[0];
+                    words.Push(subwords[1]);
+                    var wordWidth = tmpPaint.MeasureText(word);
+                    if (width + wordWidth <= maxWidth)
+                    {
+                        line.Append(word);
+                        lines.Add(line.ToString());
+                        line = new StringBuilder();
+                        width = 0;
                     }
-                    totalChars = totalChars + (int)charactersPerLine;
+                    else
+                    {
+                        if (line.Length > 0)
+                        {
+                            lines.Add(line.ToString().Trim());
+                        }
+                        lines.Add(word.ToString());
+                        line = new StringBuilder();
+                        width = 0;
+                    }
                 }
-
-            } else { 
-                textLines.Add(fieldBlock.Text.ReplaceSpecialChars());
+                else
+                {
+                    var wordWidth = tmpPaint.MeasureText(word);
+                    if (width + wordWidth <= maxWidth)
+                    {
+                        line.Append(word + " ");
+                        width += wordWidth + spaceWidth;
+                    }
+                    else
+                    {
+                        if (line.Length > 0)
+                        {
+                            lines.Add(line.ToString().Trim());
+                        }
+                        line = new StringBuilder(word + " ");
+                        width = wordWidth + spaceWidth;
+                    }
+                }
             }
 
-            return textLines;
+            lines.Add(line.ToString().Trim());
+            return lines;
         }
+
     }
 }

--- a/src/BinaryKits.Zpl.Viewer/Helpers/StringHelper.cs
+++ b/src/BinaryKits.Zpl.Viewer/Helpers/StringHelper.cs
@@ -1,7 +1,6 @@
-﻿using System;
+using System;
 using System.Globalization;
-using System.Linq;
-using System.Text;
+using System.Text.RegularExpressions;
 
 namespace BinaryKits.Zpl.Viewer.Helpers
 {
@@ -13,31 +12,14 @@ namespace BinaryKits.Zpl.Viewer.Helpers
         public static char ReplaceChar { get; set; } = '_';
 
         /// <summary>
-        /// Search for the Hexadecimal indicator and replaces it with the HEX char
+        /// Replaces hex escapes within a text.
         /// </summary>
-        /// <param name="text">String to search in</param>
-        /// <returns>Output string</returns>
-        public static string ReplaceSpecialChars(this string text)
+        /// <param name="text">Topic variable</param>
+        /// <returns>Text with hex escapes replaced with their char equivalents.</returns>
+        public static string ReplaceHexEscapes(this string text)
         {
-            if (!text.Contains(ReplaceChar))
-                return text;
-
-            StringBuilder sb = new StringBuilder();
-            for (int i = 0; i < text.Length; i++)
-            {
-                if (text[i] == ReplaceChar)
-                {
-                    string temp = text.Substring(i + 1, 2);
-                    sb.Append((char)Int16.Parse(temp, NumberStyles.AllowHexSpecifier));
-                    i = i + 2;
-                }
-                else
-                {
-                    sb.Append(text[i]);
-                }
-
-            }
-            return sb.ToString();
+            Regex hexEscapeRegex = new Regex(Regex.Escape(ReplaceChar.ToString()) + @"([0-9A-Fa-f]{2})");
+            return hexEscapeRegex.Replace(text, match => Convert.ToChar(int.Parse(match.Groups[1].Value, NumberStyles.HexNumber)).ToString());
         }
     }
 }


### PR DESCRIPTION
- Add bottomToTop to ZplFieldBlock Constructor
- Pass hangingIndent, bottomToTop to ZplFieldBlock
- Rework Hex escape replacement
  - Renames ambiguous `ReplaceSpecialChars` to `ReplaceHexEscapes`
  - Uses an interpreted Regex to avoid false positives (#112)
- Rework TextFieldElementDrawer
  - Only replace Hex Escapes if requested (see Known Issues)
  - Create rotation matrices about the correct origin, rather than adjusting placement
  - Replace hyphen with space-en dash-space (questionable! but produces fairly accurate results with most font faces)
- Rework FieldBlockElementDrawer
  - Load font face through the font loader, rather than hard-coding Arial
  - Rework word-wrapping to break on `\&`
  - Implement hangingIndent
  - Only replace Hex Escapes if requested (see Known Issues)
  - Create rotation matrices about the correct origin, rather than adjusting placement
  - Replace hyphen with space-en dash-space (questionable! but produces fairly accurate results with most font faces)

Known Issues:
---
- Labelary appears to compute the total height of FieldBlocks differently than a ZPL printer. The printer does not include a trailing line spacing in the total height, whereas Labelary does. I have chosen to emulate the printer, rather than Labelary.
- UseHexadecimalIndicator for TextFields and FieldBlocks is always passed as true (or rather, not passed at all, and defaults to true).
- `scaleX` and `fontScale` are both hard-coded to `0.95f` for TextFields and FieldBlocks. Ideally, this would be configured in the font loader on a per-font basis.

Tests:
---
```zpl
^XA
^FO300,600^GB240,152,1,B^FS
^FT300,600^A0N,32^FB240,4,8,L,12^FH^FDAdresse:\&\&Schillerstra_DFe 1\&70173 Stuttgart^FS
^FT300,600^A0R,32^FB240,4,8,L,12^FH^FDAdresse:\&\&Schillerstra_DFe 1\&70173 Stuttgart^FS
^XZ
```
First Block is placed above the bounding box, the second rotated 90° into it.

---
```zpl
^XA
^FO300,600^GB240,152,1,B^FS
^FO300,600^A0N,32^FB240,4,8,L,12^FH^FDAdresse:\&\&Schillerstra_DFe 1\&70173 Stuttgart^FS
^FO300,600^A0R,32^FB240,4,8,L,12^FH^FDAdresse:\&\&Schillerstra_DFe 1\&70173 Stuttgart^FS
^XZ
```
First Block is placed within the bounding box, the second rotated 90° within it.