### PR TITLE
Force square DataMatrix

### DIFF
--- a/src/BinaryKits.Zpl.Viewer/ElementDrawers/DataMatrixElementDrawer.cs
+++ b/src/BinaryKits.Zpl.Viewer/ElementDrawers/DataMatrixElementDrawer.cs
@@ -1,9 +1,9 @@
-﻿using BarcodeLib;
 using BinaryKits.Zpl.Label.Elements;
 using SkiaSharp;
-using System.Drawing;
+using System.Collections.Generic;
 using ZXing;
 using ZXing.Datamatrix;
+using ZXing.Datamatrix.Encoder;
 
 namespace BinaryKits.Zpl.Viewer.ElementDrawers
 {
@@ -29,7 +29,10 @@ namespace BinaryKits.Zpl.Viewer.ElementDrawers
                 }
 
                 var writer = new DataMatrixWriter();
-                var result = writer.encode(dataMatrix.Content, BarcodeFormat.DATA_MATRIX, 0, 0);
+                var hints = new Dictionary<EncodeHintType, object> {
+                    { EncodeHintType.DATA_MATRIX_SHAPE, SymbolShapeHint.FORCE_SQUARE }
+                };
+                var result = writer.encode(dataMatrix.Content, BarcodeFormat.DATA_MATRIX, 0, 0, hints);
 
                 int size = dataMatrix.Height;
                 using var image = new SKBitmap(result.Width + size - 1, result.Height + size - 1);
@@ -38,8 +41,8 @@ namespace BinaryKits.Zpl.Viewer.ElementDrawers
                 {
                     for (int col = 0; col < result.Width; col++)
                     {
-                        var color = result[row, col] ? SKColors.Black : SKColors.White;
-                        image.SetPixel(row, col, color);
+                        var color = result[col, row] ? SKColors.Black : SKColors.White;
+                        image.SetPixel(col, row, color);
                     }
                 }
 


### PR DESCRIPTION
Fixes #129
- Add a SymbolShapeHint to force the output to be square
- Fix transposed rows/cols, although irrelevant for square matrices