### PR TITLE
Add barcode interpretation lines, fix rotations

### DIFF
--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/Code39BarcodeZplCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/Code39BarcodeZplCommandAnalyzer.cs
@@ -1,4 +1,4 @@
-﻿using BinaryKits.Zpl.Label.Elements;
+using BinaryKits.Zpl.Label.Elements;
 using BinaryKits.Zpl.Viewer.Models;
 
 namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
@@ -24,11 +24,14 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
             }
             if (zplDataParts.Length > 2)
             {
-                _ = int.TryParse(zplDataParts[2], out height);
+                if (!string.IsNullOrEmpty(zplDataParts[2]))
+                {
+                    _ = int.TryParse(zplDataParts[2], out height);
+                }
             }
             if (zplDataParts.Length > 3)
             {
-                printInterpretationLine = !this.ConvertBoolean(zplDataParts[3]);
+                printInterpretationLine = this.ConvertBoolean(zplDataParts[3], "Y");
             }
             if (zplDataParts.Length > 4)
             {

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/CodeEAN13BarcodeZplCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/CodeEAN13BarcodeZplCommandAnalyzer.cs
@@ -1,4 +1,4 @@
-﻿using BinaryKits.Zpl.Label.Elements;
+using BinaryKits.Zpl.Label.Elements;
 using BinaryKits.Zpl.Viewer.Models;
 
 namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
@@ -15,16 +15,18 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
             var fieldOrientation = this.ConvertFieldOrientation(zplDataParts[0]);
             var height = this.VirtualPrinter.BarcodeInfo.Height;
             var printInterpretationLine = true;
-            var printInterpretationLineAboveCode = false;           
-           
+            var printInterpretationLineAboveCode = false;
 
             if (zplDataParts.Length > 1)
             {
-                _ = int.TryParse(zplDataParts[1], out height);
+                if (!string.IsNullOrEmpty(zplDataParts[1]))
+                {
+                    _ = int.TryParse(zplDataParts[1], out height);
+                }
             }
             if (zplDataParts.Length > 2)
             {
-                printInterpretationLine = this.ConvertBoolean(zplDataParts[2]);
+                printInterpretationLine = this.ConvertBoolean(zplDataParts[2], "Y");
             }
             if (zplDataParts.Length > 3)
             {
@@ -38,8 +40,7 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
                 FieldOrientation = fieldOrientation,
                 Height = height,
                 PrintInterpretationLine = printInterpretationLine,
-                PrintInterpretationLineAboveCode = printInterpretationLineAboveCode              
-               
+                PrintInterpretationLineAboveCode = printInterpretationLineAboveCode
             });
 
             return null;

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/DataMatrixZplCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/DataMatrixZplCommandAnalyzer.cs
@@ -1,4 +1,4 @@
-﻿using BinaryKits.Zpl.Label.Elements;
+using BinaryKits.Zpl.Label.Elements;
 using BinaryKits.Zpl.Viewer.Models;
 
 namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
@@ -12,11 +12,22 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
         {
             var zplDataParts = this.SplitCommand(zplCommand);
 
+            var fieldOrientation = this.ConvertFieldOrientation(zplDataParts[0]);
+            var height = this.VirtualPrinter.BarcodeInfo.Height;
+
+            if (zplDataParts.Length > 1)
+            {
+                if (!string.IsNullOrEmpty(zplDataParts[1]))
+                {
+                    _ = int.TryParse(zplDataParts[1], out height);
+                }
+            }
+
             //The field data are processing in the FieldDataZplCommandAnalyzer
             this.VirtualPrinter.SetNextElementFieldData(new DataMatrixFieldData
             {
-                FieldOrientation = this.ConvertFieldOrientation(zplDataParts[0]),
-                Height = this.VirtualPrinter.BarcodeInfo.Height,
+                FieldOrientation = fieldOrientation,
+                Height = height
             });
 
             return null;

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/FieldDataZplCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/FieldDataZplCommandAnalyzer.cs
@@ -48,7 +48,7 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
 
                 if (this.VirtualPrinter.NextElementFieldData is CodeEAN13BarcodeFieldData codeEAN13)
                 {
-                    return new ZplBarcodeEan13(text, x, y, codeEAN13.Height, moduleWidth, wideBarToNarrowBarWidthRatio, codeEAN13.FieldOrientation, codeEAN13.PrintInterpretationLine, codeEAN13.PrintInterpretationLineAboveCode);
+                    return new ZplBarcodeEan13(text, x, y, codeEAN13.Height, moduleWidth, wideBarToNarrowBarWidthRatio, codeEAN13.FieldOrientation, codeEAN13.PrintInterpretationLine, codeEAN13.PrintInterpretationLineAboveCode, bottomToTop);
                 }
                 if (this.VirtualPrinter.NextElementFieldData is DataMatrixFieldData dataMatrixFieldData)
                 {

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/Interleaved2of5BarcodeZplCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/Interleaved2of5BarcodeZplCommandAnalyzer.cs
@@ -1,4 +1,4 @@
-﻿using BinaryKits.Zpl.Label.Elements;
+using BinaryKits.Zpl.Label.Elements;
 using BinaryKits.Zpl.Viewer.Models;
 
 namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
@@ -20,11 +20,14 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
 
             if (zplDataParts.Length > 1)
             {
-                _ = int.TryParse(zplDataParts[1], out height);
+                if (!string.IsNullOrEmpty(zplDataParts[1]))
+                {
+                    _ = int.TryParse(zplDataParts[1], out height);
+                }
             }
             if (zplDataParts.Length > 2)
             {
-                printInterpretationLine = !this.ConvertBoolean(zplDataParts[2]);
+                printInterpretationLine = this.ConvertBoolean(zplDataParts[2], "Y");
             }
             if (zplDataParts.Length > 3)
             {

--- a/src/BinaryKits.Zpl.Viewer/ElementDrawers/Barcode128ElementDrawer.cs
+++ b/src/BinaryKits.Zpl.Viewer/ElementDrawers/Barcode128ElementDrawer.cs
@@ -81,7 +81,7 @@ namespace BinaryKits.Zpl.Viewer.ElementDrawers
                 else if (barcode.Mode == "U")
                 {
                     barcodeType = TYPE.CODE128C;
-                    content = content.Substring(0, 19).PadLeft(19, '0');
+                    content = content.PadLeft(19, '0').Substring(0, 19);
                     int checksum = 0;
                     for (int i = 0; i < 19; i++)
                     {
@@ -94,15 +94,11 @@ namespace BinaryKits.Zpl.Viewer.ElementDrawers
                 float x = barcode.PositionX;
                 float y = barcode.PositionY;
 
-                if (barcode.FieldTypeset != null)
-                {
-                    y -= barcode.Height;
-                }
-
-                float labelFontSize = barcode.ModuleWidth * 7.25f;
+                float labelFontSize = Math.Min(barcode.ModuleWidth * 7.2f, 72f);
                 var labelTypeFace = options.FontLoader("A");
                 var labelFont = new SKFont(labelTypeFace, labelFontSize).ToSystemDrawingFont();
                 int labelHeight = barcode.PrintInterpretationLine ? labelFont.Height : 0;
+                int labelHeightOffset = barcode.PrintInterpretationLineAboveCode ? labelHeight : 0;
 
                 var barcodeElement = new Barcode
                 {
@@ -115,13 +111,8 @@ namespace BinaryKits.Zpl.Viewer.ElementDrawers
                     AlternateLabel = interpretation
                 };
 
-                if (barcode.PrintInterpretationLineAboveCode)
-                {
-                    y -= labelHeight;
-                }
-
-                Image image = barcodeElement.Encode(barcodeType, content);
-                this.DrawBarcode(this.GetImageData(image), barcode.Height + labelHeight, image.Width, barcode.FieldOrigin != null, x, y, barcode.FieldOrientation);
+                using var image = barcodeElement.Encode(barcodeType, content);
+                this.DrawBarcode(this.GetImageData(image), barcode.Height, image.Width, barcode.FieldOrigin != null, x, y, labelHeightOffset, barcode.FieldOrientation);
             }
         }
     }

--- a/src/BinaryKits.Zpl.Viewer/ElementDrawers/Barcode39ElementDrawer.cs
+++ b/src/BinaryKits.Zpl.Viewer/ElementDrawers/Barcode39ElementDrawer.cs
@@ -1,5 +1,8 @@
-﻿using BarcodeLib;
+using BarcodeLib;
 using BinaryKits.Zpl.Label.Elements;
+using BinaryKits.Zpl.Viewer.Helpers;
+using SkiaSharp;
+using System;
 using System.Drawing;
 
 namespace BinaryKits.Zpl.Viewer.ElementDrawers
@@ -15,25 +18,39 @@ namespace BinaryKits.Zpl.Viewer.ElementDrawers
         ///<inheritdoc/>
         public override void Draw(ZplElementBase element)
         {
+            Draw(element, new DrawerOptions());
+        }
+
+        ///<inheritdoc/>
+        public override void Draw(ZplElementBase element, DrawerOptions options)
+        {
             if (element is ZplBarcode39 barcode)
             {
                 float x = barcode.PositionX;
                 float y = barcode.PositionY;
 
-                if (barcode.FieldTypeset != null)
-                {
-                    y -= barcode.Height;
-                }
+                var content = barcode.Content;
+                var interpretation = string.Format("*{0}*", content.Trim('*'));
+
+                float labelFontSize = Math.Min(barcode.ModuleWidth * 7.2f, 72f);
+                var labelTypeFace = options.FontLoader("A");
+                var labelFont = new SKFont(labelTypeFace, labelFontSize).ToSystemDrawingFont();
+                int labelHeight = barcode.PrintInterpretationLine ? labelFont.Height : 0;
+                int labelHeightOffset = barcode.PrintInterpretationLineAboveCode ? labelHeight : 0;
 
                 var barcodeElement = new Barcode
                 {
                     BarWidth = barcode.ModuleWidth,
                     BackColor = Color.Transparent,
-                    Height = barcode.Height
+                    Height = barcode.Height + labelHeight,
+                    IncludeLabel = barcode.PrintInterpretationLine,
+                    LabelPosition = barcode.PrintInterpretationLineAboveCode ? LabelPositions.TOPCENTER : LabelPositions.BOTTOMCENTER,
+                    LabelFont = labelFont,
+                    AlternateLabel = interpretation
                 };
 
-                using var image = barcodeElement.Encode(TYPE.CODE39Extended, barcode.Content);
-                this.DrawBarcode(this.GetImageData(image), barcode.Height, barcodeElement.Width, barcode.FieldOrigin != null, x, y, barcode.FieldOrientation);
+                using var image = barcodeElement.Encode(TYPE.CODE39Extended, content);
+                this.DrawBarcode(this.GetImageData(image), barcode.Height, image.Width, barcode.FieldOrigin != null, x, y, labelHeightOffset, barcode.FieldOrientation);
             }
         }
     }

--- a/src/BinaryKits.Zpl.Viewer/ElementDrawers/BarcodeDrawerBase.cs
+++ b/src/BinaryKits.Zpl.Viewer/ElementDrawers/BarcodeDrawerBase.cs
@@ -1,4 +1,4 @@
-﻿using SkiaSharp;
+using SkiaSharp;
 using System.Drawing;
 using System.IO;
 
@@ -22,28 +22,25 @@ namespace BinaryKits.Zpl.Viewer.ElementDrawers
             bool useFieldOrigin,
             float x,
             float y,
+            int labelHeightOffset,
             Label.FieldOrientation fieldOrientation)
         {
             using (new SKAutoCanvasRestore(this._skCanvas))
             {
                 SKMatrix matrix = SKMatrix.Empty;
-                 
+
                 if (useFieldOrigin)
                 {
                     switch (fieldOrientation)
                     {
                         case Label.FieldOrientation.Rotated90:
-                            matrix = SKMatrix.CreateRotationDegrees(90, x, y);
-                            y -= barcodeHeight;
+                            matrix = SKMatrix.CreateRotationDegrees(90, x + barcodeHeight / 2, y + barcodeHeight / 2);
                             break;
                         case Label.FieldOrientation.Rotated180:
-                            matrix = SKMatrix.CreateRotationDegrees(180, x, y);
-                            x -= barcodeWidth;
-                            y -= barcodeHeight;
+                            matrix = SKMatrix.CreateRotationDegrees(180, x + barcodeWidth / 2, y + barcodeHeight / 2);
                             break;
                         case Label.FieldOrientation.Rotated270:
-                            matrix = SKMatrix.CreateRotationDegrees(270, x, y);
-                            x -= barcodeWidth;
+                            matrix = SKMatrix.CreateRotationDegrees(270, x + barcodeWidth / 2, y + barcodeWidth / 2);
                             break;
                         case Label.FieldOrientation.Normal:
                             break;
@@ -55,29 +52,27 @@ namespace BinaryKits.Zpl.Viewer.ElementDrawers
                     {
                         case Label.FieldOrientation.Rotated90:
                             matrix = SKMatrix.CreateRotationDegrees(90, x, y);
-                            y -= barcodeHeight;
-                            x += barcodeHeight;
                             break;
                         case Label.FieldOrientation.Rotated180:
                             matrix = SKMatrix.CreateRotationDegrees(180, x, y);
-                            y -= barcodeHeight * 2;
                             break;
                         case Label.FieldOrientation.Rotated270:
                             matrix = SKMatrix.CreateRotationDegrees(270, x, y);
-                            y -= barcodeHeight;
-                            x -= barcodeHeight;
                             break;
                         case Label.FieldOrientation.Normal:
                             break;
                     }
+                    y -= barcodeHeight;
                 }
+
+                y -= labelHeightOffset;
 
                 if (matrix != SKMatrix.Empty)
                 {
                     this._skCanvas.SetMatrix(matrix);
                 }
 
-                this._skCanvas.DrawBitmap(SKBitmap.Decode(barcodeImageData), x, y);
+                this._skCanvas.DrawBitmap(SKBitmap.Decode(barcodeImageData), x, y );
             }
         }
     }

--- a/src/BinaryKits.Zpl.Viewer/ElementDrawers/BarcodeEAN13ElementDrawer.cs
+++ b/src/BinaryKits.Zpl.Viewer/ElementDrawers/BarcodeEAN13ElementDrawer.cs
@@ -1,7 +1,9 @@
-﻿using BarcodeLib;
+using BarcodeLib;
 using BinaryKits.Zpl.Label.Elements;
+using BinaryKits.Zpl.Viewer.Helpers;
+using SkiaSharp;
+using System;
 using System.Drawing;
-
 
 namespace BinaryKits.Zpl.Viewer.ElementDrawers
 {
@@ -15,34 +17,51 @@ namespace BinaryKits.Zpl.Viewer.ElementDrawers
         ///<inheritdoc/>
         public override void Draw(ZplElementBase element)
         {
+            Draw(element, new DrawerOptions());
+        }
+
+        ///<inheritdoc/>
+        public override void Draw(ZplElementBase element, DrawerOptions options)
+        {
             if (element is ZplBarcodeEan13 barcode)
             {
                 float x = barcode.PositionX;
                 float y = barcode.PositionY;
 
-                if (barcode.FieldTypeset != null)
+                var content = barcode.Content;
+                content = content.PadLeft(12, '0').Substring(0, 12);
+                var interpretation = content;
+
+                if (barcode.PrintInterpretationLineAboveCode)
                 {
-                    y -= barcode.Height;
+                    int checksum = 0;
+                    for (int i = 0; i < 12; i++)
+                    {
+                        checksum += (content[i] - 48) * (9 - i % 2 * 2);
+                    }
+                    interpretation = string.Format("{0}{1}", interpretation, checksum % 10);
                 }
+
+                float labelFontSize = Math.Min(barcode.ModuleWidth * 7.2f, 72f);
+                var labelTypeFace = options.FontLoader("A");
+                var labelFont = new SKFont(labelTypeFace, labelFontSize).ToSystemDrawingFont();
+                int labelHeight = barcode.PrintInterpretationLine ? labelFont.Height : 0;
+                int labelHeightOffset = barcode.PrintInterpretationLineAboveCode ? labelHeight : 0;
 
                 var barcodeElement = new Barcode
                 {
                     BarWidth = barcode.ModuleWidth,
-                    BackColor = Color.Transparent,
-                    Height = barcode.Height                
+                    BackColor = Color.White,
+                    Height = barcode.Height + labelHeight,
+                    IncludeLabel = barcode.PrintInterpretationLine,
+                    LabelPosition = barcode.PrintInterpretationLineAboveCode ? LabelPositions.TOPCENTER : LabelPositions.BOTTOMCENTER,
+                    LabelFont = labelFont,
+                    AlternateLabel = interpretation,
+                    StandardizeLabel = !barcode.PrintInterpretationLineAboveCode
                 };
 
-                var content = barcode.Content;
-                if(content.Length < 12)
-                {
-                    var number = long.Parse(content);
-                    content = number.ToString("D12");
-                }else if(content.Length > 12)
-                {
-                    content = content.Substring(content.Length - 12, 12);
-                }
                 using var image = barcodeElement.Encode(TYPE.EAN13, content);
-                this.DrawBarcode(this.GetImageData(image), barcode.Height, image.Width, barcode.FieldOrigin != null, x, y, barcode.FieldOrientation);
+                this.DrawBarcode(this.GetImageData(image), barcode.Height, image.Width, barcode.FieldOrigin != null, x, y, labelHeightOffset, barcode.FieldOrientation);
             }
         }
     }

--- a/src/BinaryKits.Zpl.Viewer/ElementDrawers/DataMatrixElementDrawer.cs
+++ b/src/BinaryKits.Zpl.Viewer/ElementDrawers/DataMatrixElementDrawer.cs
@@ -23,11 +23,6 @@ namespace BinaryKits.Zpl.Viewer.ElementDrawers
                 float x = dataMatrix.PositionX;
                 float y = dataMatrix.PositionY;
 
-                if (dataMatrix.FieldTypeset != null)
-                {
-                    y -= dataMatrix.Height;
-                }
-
                 var writer = new DataMatrixWriter();
                 var hints = new Dictionary<EncodeHintType, object> {
                     { EncodeHintType.DATA_MATRIX_SHAPE, SymbolShapeHint.FORCE_SQUARE }
@@ -35,7 +30,7 @@ namespace BinaryKits.Zpl.Viewer.ElementDrawers
                 var result = writer.encode(dataMatrix.Content, BarcodeFormat.DATA_MATRIX, 0, 0, hints);
 
                 int size = dataMatrix.Height;
-                using var image = new SKBitmap(result.Width + size - 1, result.Height + size - 1);
+                using var image = new SKBitmap(result.Width, result.Height);
 
                 for (int row = 0; row < result.Height; row++)
                 {
@@ -49,7 +44,7 @@ namespace BinaryKits.Zpl.Viewer.ElementDrawers
                 using var resizedImage = image.Resize(new SKSizeI(image.Width * size, image.Height * size), SKFilterQuality.None);
 
                 var png = resizedImage.Encode(SKEncodedImageFormat.Png, 100).ToArray();
-                this.DrawBarcode(png, dataMatrix.Height, dataMatrix.Height, dataMatrix.FieldOrigin != null, x, y, dataMatrix.FieldOrientation);
+                this.DrawBarcode(png, resizedImage.Height, resizedImage.Width, dataMatrix.FieldOrigin != null, x, y, 0, dataMatrix.FieldOrientation);
             }
         }
     }


### PR DESCRIPTION
- Adds interpretation lines for EAN13, Interleaved2of5, and Code39.
- Simplifies barcode rotation logic, Code128 is updated accordingly.
- Parses height for DataMatrix (previously always 10).

Known Issues:
---
- EAN13 and I2of5 do not support variable WideToNarrow ratio (always 2).
- EAN13 interpretation lines do not respect chosen font face / font size.
- EAN13 are drawn with a white background, and may hide other elements (required by BarcodeLib).

Discussion:
---
Using BarcodeLib presents a lot of limitations. Ultimately, it may be a good idea to rely solely on ZXing, and render from encoded data, as is done for DataMatrix.

Tests:
---
The font face used for Font "A" in the following tests is DejuVuSansMono. Images show labelary overlay in red.

Code39, interpretation line below:
```zpl
^XA

^FO130,30^BY3,2^B3N,N,100,Y,N^FD0DEGREE^FS
^FO30,130^BY3,2^B3R,N,100,Y,N^FD90DEGREE^FS
^FO280,180^BY3,2^B3I,N,100,Y,N^FD180DEGREE^FS
^FO180,280^BY3,2^B3B,N,100,Y,N^FD270DEGREE^FS

^FT450,750^BY3,2^B3N,N,100,Y,N^FD0DEGREE^FS
^FT450,750^BY3,2^B3R,N,100,Y,N^FD90DEGREE^FS
^FT450,750^BY3,2^B3I,N,100,Y,N^FD180DEGREE^FS
^FT450,750^BY3,2^B3B,N,100,Y,N^FD270DEGREE^FS

^XZ
```
<img src="https://user-images.githubusercontent.com/4907320/184664690-f030d38f-6aa4-40bb-b89d-d75117e6e55f.png" width="400" />

---
Code39, interpretation line above:
```zpl
^XA

^FO130,30^BY3,2^B3N,N,100,Y,Y^FD0DEGREE^FS
^FO30,130^BY3,2^B3R,N,100,Y,Y^FD90DEGREE^FS
^FO280,180^BY3,2^B3I,N,100,Y,Y^FD180DEGREE^FS
^FO180,280^BY3,2^B3B,N,100,Y,Y^FD270DEGREE^FS

^FT450,750^BY3,2^B3N,N,100,Y,Y^FD0DEGREE^FS
^FT450,750^BY3,2^B3R,N,100,Y,Y^FD90DEGREE^FS
^FT450,750^BY3,2^B3I,N,100,Y,Y^FD180DEGREE^FS
^FT450,750^BY3,2^B3B,N,100,Y,Y^FD270DEGREE^FS

^XZ
```
<img src="https://user-images.githubusercontent.com/4907320/184665081-a613dcbb-1f28-4e84-a5bb-bf0450da74d4.png" width="400" />

---
I2of5, interpretation line below:
```zpl
^XA

^FO130,30^BY3,2^B2N,100,Y,N^FD123456789012^FS
^FO30,130^BY3,2^B2R,100,Y,N^FD123456789012^FS
^FO280,180^BY3,2^B2I,100,Y,N^FD123456789012^FS
^FO180,280^BY3,2^B2B,100,Y,N^FD123456789012^FS

^FT450,750^BY3,2^B2N,100,Y,N^FD123456789012^FS
^FT450,750^BY3,2^B2R,100,Y,N^FD123456789012^FS
^FT450,750^BY3,2^B2I,100,Y,N^FD123456789012^FS
^FT450,750^BY3,2^B2B,100,Y,N^FD123456789012^FS

^XZ
```
<img src="https://user-images.githubusercontent.com/4907320/184665582-f834b841-e5a8-4075-afdf-deacf8b72d4c.png" width="400" />

---
I2of5, interpretation line above:
```zpl
^XA

^FO130,30^BY3,2^B2N,100,Y,Y^FD123456789012^FS
^FO30,130^BY3,2^B2R,100,Y,Y^FD123456789012^FS
^FO280,180^BY3,2^B2I,100,Y,Y^FD123456789012^FS
^FO180,280^BY3,2^B2B,100,Y,Y^FD123456789012^FS

^FT450,750^BY3,2^B2N,100,Y,Y^FD123456789012^FS
^FT450,750^BY3,2^B2R,100,Y,Y^FD123456789012^FS
^FT450,750^BY3,2^B2I,100,Y,Y^FD123456789012^FS
^FT450,750^BY3,2^B2B,100,Y,Y^FD123456789012^FS

^XZ
```
<img src="https://user-images.githubusercontent.com/4907320/184665939-8db21a4b-eab0-4b67-8be4-d9b717447163.png" width="400" />

---
Code128, interpretation line below:
```zpl
^XA

^FO130,30^BY2,2^BCN,100,Y,N^FD0 degrees^FS
^FO30,130^BY2,2^BCR,100,Y,N^FD90 degrees^FS
^FO280,180^BY2,2^BCI,100,Y,N^FD180 degrees^FS
^FO180,280^BY2,2^BCB,100,Y,N^FD270 degrees^FS

^FT450,750^BY2,2^BCN,100,Y,N^FD0 degrees^FS
^FT450,750^BY2,2^BCR,100,Y,N^FD90 degrees^FS
^FT450,750^BY2,2^BCI,100,Y,N^FD180 degrees^FS
^FT450,750^BY2,2^BCB,100,Y,N^FD270 degrees^FS

^XZ
```
<img src="https://user-images.githubusercontent.com/4907320/184666255-8d2cb313-679d-404e-bc4a-84c650592ad1.png" width="400" />

---
Code128, interpretation line above:
```zpl
^XA

^FO130,30^BY2,2^BCN,100,Y,Y^FD0 degrees^FS
^FO30,130^BY2,2^BCR,100,Y,Y^FD90 degrees^FS
^FO280,180^BY2,2^BCI,100,Y,Y^FD180 degrees^FS
^FO180,280^BY2,2^BCB,100,Y,Y^FD270 degrees^FS

^FT450,750^BY2,2^BCN,100,Y,Y^FD0 degrees^FS
^FT450,750^BY2,2^BCR,100,Y,Y^FD90 degrees^FS
^FT450,750^BY2,2^BCI,100,Y,Y^FD180 degrees^FS
^FT450,750^BY2,2^BCB,100,Y,Y^FD270 degrees^FS

^XZ
```
<img src="https://user-images.githubusercontent.com/4907320/184666685-f1955ba0-beb7-4e6a-8be9-a04c6c253274.png" width="400" />

---
EAN13, interpretation line below:
```zpl
^XA

^FO130,30^BY3,2^BEN,100,Y,N^FD123456789012^FS
^FO30,130^BY3,2^BER,100,Y,N^FD123456789012^FS
^FO280,180^BY3,2^BEI,100,Y,N^FD123456789012^FS
^FO180,280^BY3,2^BEB,100,Y,N^FD123456789012^FS

^FT450,750^BY3,2^BEN,100,Y,N^FD123456789012^FS
^FT450,750^BY3,2^BER,100,Y,N^FD123456789012^FS
^FT450,750^BY3,2^BEI,100,Y,N^FD123456789012^FS
^FT450,750^BY3,2^BEB,100,Y,N^FD123456789012^FS

^XZ
```
<img src="https://user-images.githubusercontent.com/4907320/184667106-bcf8f6da-4ff3-48c8-812c-076abafc07a8.png" width="400" />

---
EAN13, interpretation line above:
```zpl
^XA

^FO130,30^BY3,2^BEN,100,Y,Y^FD123456789012^FS
^FO30,130^BY3,2^BER,100,Y,Y^FD123456789012^FS
^FO280,180^BY3,2^BEI,100,Y,Y^FD123456789012^FS
^FO180,280^BY3,2^BEB,100,Y,Y^FD123456789012^FS

^FT450,750^BY3,2^BEN,100,Y,Y^FD123456789012^FS
^FT450,750^BY3,2^BER,100,Y,Y^FD123456789012^FS
^FT450,750^BY3,2^BEI,100,Y,Y^FD123456789012^FS
^FT450,750^BY3,2^BEB,100,Y,Y^FD123456789012^FS

^XZ
```
<img src="https://user-images.githubusercontent.com/4907320/184667444-56c0271c-6ae3-44e9-8491-de3caa351a57.png" width="400" />

---
Variously sized EAN13 without overlay:
```zpl
^XA

^FO10,20^BY1^BEN,60,Y,N^FD123456789012^FS
^FO10,110^BY2^BEN,100,Y,N^FD123456789012^FS
^FO10,250^BY3^BEN,140,Y,N^FD123456789012^FS
^FO10,450^BY4^BEN,180,Y,N^FD123456789012^FS
^FO10,710^BY5^BEN,220,Y,N^FD123456789012^FS

^XZ
```
<img src="https://user-images.githubusercontent.com/4907320/184667973-8b671b91-ba7c-472c-9fca-bd8547ebf080.png" width="400" />

---
DataMatrix, various sizes and rotations:
```zpl
^XA

^FO30,30^BXN,2,200^FDABC^FS
^FO30,70^BXN,4,200^FDABC^FS
^FO30,130^BXN,6,200^FDABC^FS
^FO30,210^BXN,8,200^FDABC^FS
^FO30,310^BXN,10,200^FDABC^FS

^FO280,30^BXN,10,200^FDABC^FS
^FO180,130^BXR,10,200^FDABC^FS
^FO380,130^BXI,10,200^FDABC^FS
^FO280,230^BXB,10,200^FDABC^FS

^FT280,470^BXN,10,200^FDABC^FS
^FT280,470^BXR,10,200^FDABC^FS
^FT280,470^BXI,10,200^FDABC^FS
^FT280,470^BXB,10,200^FDABC^FS

^XZ
```
<img src="https://user-images.githubusercontent.com/4907320/184670102-6b8dd723-4b5f-4f93-b82a-1e74d887be50.png" width="400" />

