### PR TITLE
Make storage location optional for ~DG, ^XG

### DIFF
--- a/src/BinaryKits.Zpl.Label/Elements/ZplRecallGraphic.cs
+++ b/src/BinaryKits.Zpl.Label/Elements/ZplRecallGraphic.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 namespace BinaryKits.Zpl.Label.Elements
@@ -20,8 +20,9 @@ namespace BinaryKits.Zpl.Label.Elements
             char storageDevice,
             string imageName,
             int magnificationFactorX = 1,
-            int magnificationFactorY = 1)
-            : base(positionX, positionY)
+            int magnificationFactorY = 1,
+            bool bottomToTop = false)
+            : base(positionX, positionY, bottomToTop)
         {
             if (imageName.Length > 8)
             {

--- a/src/BinaryKits.Zpl.Viewer/ElementDrawers/RecallGraphicElementDrawer.cs
+++ b/src/BinaryKits.Zpl.Viewer/ElementDrawers/RecallGraphicElementDrawer.cs
@@ -1,4 +1,4 @@
-﻿using BinaryKits.Zpl.Label.Elements;
+using BinaryKits.Zpl.Label.Elements;
 using SkiaSharp;
 
 namespace BinaryKits.Zpl.Viewer.ElementDrawers
@@ -25,8 +25,13 @@ namespace BinaryKits.Zpl.Viewer.ElementDrawers
 
                 var x = recallGraphic.PositionX;
                 var y = recallGraphic.PositionY;
+                var bitmap = SKBitmap.Decode(imageData);
+                if (recallGraphic.FieldTypeset != null)
+                {
+                    y -= bitmap.Height;
+                }
 
-                this._skCanvas.DrawBitmap(SKBitmap.Decode(imageData), x, y);
+                this._skCanvas.DrawBitmap(bitmap, x, y);
             }
         }
     }

--- a/src/BinaryKits.Zpl.Viewer/PrinterStorage.cs
+++ b/src/BinaryKits.Zpl.Viewer/PrinterStorage.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 
 namespace BinaryKits.Zpl.Viewer
@@ -35,7 +35,7 @@ namespace BinaryKits.Zpl.Viewer
             if (this._cache.TryGetValue(storageDevice, out var files))
             {
                 files.TryGetValue(fileName, out var data);
-                return data;
+                return data ?? Array.Empty<byte>();
             }
 
             return Array.Empty<byte>();


### PR DESCRIPTION
- Make storage location optional for DownloadGraphic, RecallGraphic (default R)
- Avoid returning null on storage miss (#132)
- Correctly position RecallGraphic under ^FT