### PR TITLE
Use RenderPosition for PositionedElements

### DIFF
--- a/src/BinaryKits.Zpl.Label/Elements/ZplBarcode128.cs
+++ b/src/BinaryKits.Zpl.Label/Elements/ZplBarcode128.cs
@@ -59,7 +59,7 @@ namespace BinaryKits.Zpl.Label.Elements
             //^BCN,100,Y,N,N
             //^FD123456 ^ FS
             var result = new List<string>();
-            result.AddRange(FieldOrigin.Render(context));
+            result.AddRange(RenderPosition(context));
             result.Add($"^BC{RenderFieldOrientation()},{context.Scale(Height)},{RenderPrintInterpretationLine()},{RenderPrintInterpretationLineAboveCode()}");
             result.Add($"^FD{Content}^FS");
 

--- a/src/BinaryKits.Zpl.Label/Elements/ZplBarcode39.cs
+++ b/src/BinaryKits.Zpl.Label/Elements/ZplBarcode39.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace BinaryKits.Zpl.Label.Elements
 {
@@ -56,7 +56,7 @@ namespace BinaryKits.Zpl.Label.Elements
             //^BCN,100,Y,N,N
             //^FD123456 ^ FS
             var result = new List<string>();
-            result.AddRange(FieldOrigin.Render(context));
+            result.AddRange(RenderPosition(context));
             result.Add($"^B3{RenderFieldOrientation()},{(Mod43CheckDigit ? "Y" : "N")},{context.Scale(Height)},{RenderPrintInterpretationLine()},{RenderPrintInterpretationLineAboveCode()}");
             result.Add($"^FD{Content}^FS");
 

--- a/src/BinaryKits.Zpl.Label/Elements/ZplBarcodeAnsiCodabar.cs
+++ b/src/BinaryKits.Zpl.Label/Elements/ZplBarcodeAnsiCodabar.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -82,7 +82,7 @@ namespace BinaryKits.Zpl.Label.Elements
             // ^ BKN,N,150,Y,N,A,A
             //  ^ FD123456 ^ FS
             var result = new List<string>();
-            result.AddRange(FieldOrigin.Render(context));
+            result.AddRange(RenderPosition(context));
             result.Add($"^BK{RenderFieldOrientation()},{(CheckDigit ? "Y" : "N")},{context.Scale(Height)},{RenderPrintInterpretationLine()},{RenderPrintInterpretationLineAboveCode()},{StartCharacter},{StopCharacter}");
             result.Add($"^FD{Content}^FS");
 

--- a/src/BinaryKits.Zpl.Label/Elements/ZplBarcodeEan13.cs
+++ b/src/BinaryKits.Zpl.Label/Elements/ZplBarcodeEan13.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 namespace BinaryKits.Zpl.Label.Elements
@@ -53,7 +53,7 @@ namespace BinaryKits.Zpl.Label.Elements
         public override IEnumerable<string> Render(ZplRenderOptions context)
         {
             var result = new List<string>();
-            result.AddRange(FieldOrigin.Render(context));
+            result.AddRange(RenderPosition(context));
             result.Add($"^BE{RenderFieldOrientation()},{context.Scale(Height)},{RenderPrintInterpretationLine()},{RenderPrintInterpretationLineAboveCode()}");
             result.Add($"^FD{Content}^FS");
 

--- a/src/BinaryKits.Zpl.Label/Elements/ZplBarcodeInterleaved2of5.cs
+++ b/src/BinaryKits.Zpl.Label/Elements/ZplBarcodeInterleaved2of5.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 namespace BinaryKits.Zpl.Label.Elements
@@ -59,7 +59,7 @@ namespace BinaryKits.Zpl.Label.Elements
         public override IEnumerable<string> Render(ZplRenderOptions context)
         {
             var result = new List<string>();
-            result.AddRange(FieldOrigin.Render(context));
+            result.AddRange(RenderPosition(context));
             result.Add($"^B2{RenderFieldOrientation()},{context.Scale(Height)},{RenderPrintInterpretationLine()},{RenderPrintInterpretationLineAboveCode()},{(Mod10CheckDigit ? "Y" : "N")}");
             result.Add($"^FD{Content}^FS");
 

--- a/src/BinaryKits.Zpl.Label/Elements/ZplDataMatrix.cs
+++ b/src/BinaryKits.Zpl.Label/Elements/ZplDataMatrix.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace BinaryKits.Zpl.Label.Elements
 {
@@ -49,7 +49,7 @@ namespace BinaryKits.Zpl.Label.Elements
             //^BXN,10,200
             //^FDZEBRA TECHNOLOGIES CORPORATION ^ FS
             var result = new List<string>();
-            result.AddRange(FieldOrigin.Render(context));
+            result.AddRange(RenderPosition(context));
             result.Add($"^BX{RenderFieldOrientation()},{context.Scale(Height)}");
             result.Add($"^FD{Content}^FS");
 

--- a/src/BinaryKits.Zpl.Label/Elements/ZplFieldBlock.cs
+++ b/src/BinaryKits.Zpl.Label/Elements/ZplFieldBlock.cs
@@ -69,7 +69,7 @@ namespace BinaryKits.Zpl.Label.Elements
             // ^ XZ
             var result = new List<string>();
             result.AddRange(Font.Render(context));
-            result.AddRange(FieldOrigin.Render(context));
+            result.AddRange(RenderPosition(context));
             result.Add($"^FB{context.Scale(Width)},{MaxLineCount},{context.Scale(LineSpace)},{RenderTextJustification()},{context.Scale(HangingIndent)}");
             result.Add(RenderFieldDataSection());
 

--- a/src/BinaryKits.Zpl.Label/Elements/ZplGraphicBox.cs
+++ b/src/BinaryKits.Zpl.Label/Elements/ZplGraphicBox.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace BinaryKits.Zpl.Label.Elements
 {
@@ -34,7 +34,7 @@ namespace BinaryKits.Zpl.Label.Elements
             //^ FO50,50
             //^ GB300,200,10 ^ FS
             var result = new List<string>();
-            result.AddRange(FieldOrigin.Render(context));
+            result.AddRange(RenderPosition(context));
             result.Add($"^GB{context.Scale(Width)},{context.Scale(Height)},{context.Scale(BorderThickness)},{RenderLineColor(LineColor)},{context.Scale(CornerRounding)}^FS");
 
             return result;

--- a/src/BinaryKits.Zpl.Label/Elements/ZplGraphicCircle.cs
+++ b/src/BinaryKits.Zpl.Label/Elements/ZplGraphicCircle.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace BinaryKits.Zpl.Label.Elements
 {
@@ -35,7 +35,7 @@ namespace BinaryKits.Zpl.Label.Elements
         {
             //^GCd,t,c
             var result = new List<string>();
-            result.AddRange(FieldOrigin.Render(context));
+            result.AddRange(RenderPosition(context));
             result.Add($"^GC{context.Scale(Diameter)},{context.Scale(BorderThickness)},{RenderLineColor(LineColor)}^FS");
 
             return result;

--- a/src/BinaryKits.Zpl.Label/Elements/ZplGraphicDiagonalLine.cs
+++ b/src/BinaryKits.Zpl.Label/Elements/ZplGraphicDiagonalLine.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace BinaryKits.Zpl.Label.Elements
 {
@@ -24,7 +24,7 @@ namespace BinaryKits.Zpl.Label.Elements
         {
             //^GDw,h,t,c,o
             var result = new List<string>();
-            result.AddRange(FieldOrigin.Render(context));
+            result.AddRange(RenderPosition(context));
             result.Add($"^GD{context.Scale(Width)},{context.Scale(Height)},{context.Scale(BorderThickness)},{RenderLineColor(LineColor)},{(RightLeaningDiagonal ? "R" : "L")}^FS");
 
             return result;

--- a/src/BinaryKits.Zpl.Label/Elements/ZplGraphicEllipse.cs
+++ b/src/BinaryKits.Zpl.Label/Elements/ZplGraphicEllipse.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace BinaryKits.Zpl.Label.Elements
 {
@@ -20,7 +20,7 @@ namespace BinaryKits.Zpl.Label.Elements
         {
             //^ GE300,100,10,B ^ FS
             var result = new List<string>();
-            result.AddRange(FieldOrigin.Render(context));
+            result.AddRange(RenderPosition(context));
             result.Add($"^GE{context.Scale(Width)},{context.Scale(Height)},{context.Scale(BorderThickness)},{RenderLineColor(LineColor)}^FS");
 
             return result;

--- a/src/BinaryKits.Zpl.Label/Elements/ZplGraphicField.cs
+++ b/src/BinaryKits.Zpl.Label/Elements/ZplGraphicField.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace BinaryKits.Zpl.Label.Elements
 {
@@ -39,7 +39,7 @@ namespace BinaryKits.Zpl.Label.Elements
         public override IEnumerable<string> Render(ZplRenderOptions context)
         {
             var result = new List<string>();
-            result.AddRange(FieldOrigin.Render(context));
+            result.AddRange(RenderPosition(context));
             result.Add($"^GF{CompressionType},{BinaryByteCount},{GraphicFieldCount},{BytesPerRow},{Data}");
 
             return result;

--- a/src/BinaryKits.Zpl.Label/Elements/ZplGraphicSymbol.cs
+++ b/src/BinaryKits.Zpl.Label/Elements/ZplGraphicSymbol.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace BinaryKits.Zpl.Label.Elements
 {
@@ -52,7 +52,7 @@ namespace BinaryKits.Zpl.Label.Elements
         {
             //^GSo,h,w
             var result = new List<string>();
-            result.AddRange(FieldOrigin.Render(context));
+            result.AddRange(RenderPosition(context));
             result.Add($"^GS{RenderFieldOrientation(FieldOrientation)},{context.Scale(Height)},{context.Scale(Width)}^FD{CharacterLetter}^FS");
 
             return result;

--- a/src/BinaryKits.Zpl.Label/Elements/ZplImageMove.cs
+++ b/src/BinaryKits.Zpl.Label/Elements/ZplImageMove.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace BinaryKits.Zpl.Label.Elements
 {
@@ -39,7 +39,7 @@ namespace BinaryKits.Zpl.Label.Elements
         public override IEnumerable<string> Render(ZplRenderOptions context)
         {
             var result = new List<string>();
-            result.AddRange(FieldOrigin.Render(context));
+            result.AddRange(RenderPosition(context));
             result.Add($"^IM{StorageDevice}:{ObjectName}.{Extension}");
 
             return result;

--- a/src/BinaryKits.Zpl.Label/Elements/ZplQrCode.cs
+++ b/src/BinaryKits.Zpl.Label/Elements/ZplQrCode.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace BinaryKits.Zpl.Label.Elements
 {
@@ -47,7 +47,7 @@ namespace BinaryKits.Zpl.Label.Elements
             //^ BQN,2,10
             //^ FDMM,AAC - 42 ^ FS
             var result = new List<string>();
-            result.AddRange(FieldOrigin.Render(context));
+            result.AddRange(RenderPosition(context));
             result.Add($"^BQN,{Model},{context.Scale(MagnificationFactor)},{RenderErrorCorrectionLevel(ErrorCorrectionLevel)},{MaskValue}");
             result.Add($"^FD{RenderErrorCorrectionLevel(ErrorCorrectionLevel)}A,{Content}^FS");
 

--- a/src/BinaryKits.Zpl.Label/Elements/ZplRecallGraphic.cs
+++ b/src/BinaryKits.Zpl.Label/Elements/ZplRecallGraphic.cs
@@ -41,7 +41,7 @@ namespace BinaryKits.Zpl.Label.Elements
         public override IEnumerable<string> Render(ZplRenderOptions context)
         {
             var result = new List<string>();
-            result.AddRange(FieldOrigin.Render(context));
+            result.AddRange(RenderPosition(context));
             result.Add($"^XG{StorageDevice}:{ImageName}.{_extension},{MagnificationFactorX},{MagnificationFactorY}^FS");
 
             return result;

--- a/src/BinaryKits.Zpl.Label/Elements/ZplTextBlock.cs
+++ b/src/BinaryKits.Zpl.Label/Elements/ZplTextBlock.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 namespace BinaryKits.Zpl.Label.Elements
@@ -39,7 +39,7 @@ namespace BinaryKits.Zpl.Label.Elements
         {
             var result = new List<string>();
             result.AddRange(Font.Render(context));
-            result.AddRange(FieldOrigin.Render(context));
+            result.AddRange(RenderPosition(context));
             result.Add($"^TB{RenderFieldOrientation(Font.FieldOrientation)},{context.Scale(Width)},{context.Scale(Height)}");
             result.Add(RenderFieldDataSection());
 


### PR DESCRIPTION
Prevents null reference exception when using FieldTypeset (`^FT`), as FieldOrigin is null.