### PR TITLE
Include inner exception when throwing

### DIFF
--- a/src/BinaryKits.Zpl.Viewer/ZplElementDrawer.cs
+++ b/src/BinaryKits.Zpl.Viewer/ZplElementDrawer.cs
@@ -91,7 +91,7 @@ namespace BinaryKits.Zpl.Viewer
                 {
                     if (element is ZplBarcode)
                     {
-                        throw new Exception($"Error on zpl element \"{(element as ZplBarcode).Content}\": {ex.Message}");
+                        throw new Exception($"Error on zpl element \"{(element as ZplBarcode).Content}\": {ex.Message}", ex);
                     }
                     else
                     {


### PR DESCRIPTION
### WHAT
Include the inner exception when throwing exception.

### WHY
I ran into an issue running this on in AWS Lambda. It had to do with libgdiplus not being installed, but all I was getting was:
> Error on zpl element "12345678": The type initializer for 'Gdip' threw an exception.

After this change, the exception will contain the inner exception, which was:
> Unable to load shared library 'libgdiplus' or one of its dependencies. In order to help diagnose loading problems, consider setting the LD_DEBUG environment variable: liblibgdiplus: cannot open shared object file: No such file or directory

This is very helpful when troubleshooting.

