### PR TITLE
Added Modulewidth rendering (#104)

### DIFF
--- a/src/BinaryKits.Zpl.Label/BinaryKits.Zpl.Label.csproj
+++ b/src/BinaryKits.Zpl.Label/BinaryKits.Zpl.Label.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net472;netstandard2.0;net6.0</TargetFrameworks>
     <Description>This package allows you to simply and reliably prepare labels complying with the Zebra programming language, using predefined class/typing. It also supports you with image conversion.</Description>
     <Company>Binary Kits Pte. Ltd.</Company>
-    <Version>3.1.2</Version>
+    <Version>3.1.3</Version>
     <Authors>Binary Kits Pte. Ltd.</Authors>
     <PackageReleaseNotes></PackageReleaseNotes>
     <PackageTags>Zebra ZPL ZPL2 Printer Label</PackageTags>

--- a/src/BinaryKits.Zpl.Label/Elements/ZplBarcode.cs
+++ b/src/BinaryKits.Zpl.Label/Elements/ZplBarcode.cs
@@ -53,6 +53,11 @@
             return RenderFieldOrientation(FieldOrientation);
         }
 
+        protected string RenderModuleWidth()
+        {
+            return $"^BY{ModuleWidth}";
+        }
+
         protected bool IsDigitsOnly(string text)
         {
             foreach (char c in text)

--- a/src/BinaryKits.Zpl.Label/Elements/ZplBarcode128.cs
+++ b/src/BinaryKits.Zpl.Label/Elements/ZplBarcode128.cs
@@ -60,6 +60,7 @@ namespace BinaryKits.Zpl.Label.Elements
             //^FD123456 ^ FS
             var result = new List<string>();
             result.AddRange(RenderPosition(context));
+            result.Add(RenderModuleWidth());
             result.Add($"^BC{RenderFieldOrientation()},{context.Scale(Height)},{RenderPrintInterpretationLine()},{RenderPrintInterpretationLineAboveCode()}");
             result.Add($"^FD{Content}^FS");
 

--- a/src/BinaryKits.Zpl.Label/Elements/ZplBarcode39.cs
+++ b/src/BinaryKits.Zpl.Label/Elements/ZplBarcode39.cs
@@ -57,6 +57,7 @@ namespace BinaryKits.Zpl.Label.Elements
             //^FD123456 ^ FS
             var result = new List<string>();
             result.AddRange(RenderPosition(context));
+            result.Add(RenderModuleWidth());
             result.Add($"^B3{RenderFieldOrientation()},{(Mod43CheckDigit ? "Y" : "N")},{context.Scale(Height)},{RenderPrintInterpretationLine()},{RenderPrintInterpretationLineAboveCode()}");
             result.Add($"^FD{Content}^FS");
 

--- a/src/BinaryKits.Zpl.Label/Elements/ZplBarcodeAnsiCodabar.cs
+++ b/src/BinaryKits.Zpl.Label/Elements/ZplBarcodeAnsiCodabar.cs
@@ -83,6 +83,7 @@ namespace BinaryKits.Zpl.Label.Elements
             //  ^ FD123456 ^ FS
             var result = new List<string>();
             result.AddRange(RenderPosition(context));
+            result.Add(RenderModuleWidth());
             result.Add($"^BK{RenderFieldOrientation()},{(CheckDigit ? "Y" : "N")},{context.Scale(Height)},{RenderPrintInterpretationLine()},{RenderPrintInterpretationLineAboveCode()},{StartCharacter},{StopCharacter}");
             result.Add($"^FD{Content}^FS");
 

--- a/src/BinaryKits.Zpl.Label/Elements/ZplBarcodeEan13.cs
+++ b/src/BinaryKits.Zpl.Label/Elements/ZplBarcodeEan13.cs
@@ -54,6 +54,7 @@ namespace BinaryKits.Zpl.Label.Elements
         {
             var result = new List<string>();
             result.AddRange(RenderPosition(context));
+            result.Add(RenderModuleWidth());
             result.Add($"^BE{RenderFieldOrientation()},{context.Scale(Height)},{RenderPrintInterpretationLine()},{RenderPrintInterpretationLineAboveCode()}");
             result.Add($"^FD{Content}^FS");
 

--- a/src/BinaryKits.Zpl.Label/Elements/ZplBarcodeInterleaved2of5.cs
+++ b/src/BinaryKits.Zpl.Label/Elements/ZplBarcodeInterleaved2of5.cs
@@ -60,6 +60,7 @@ namespace BinaryKits.Zpl.Label.Elements
         {
             var result = new List<string>();
             result.AddRange(RenderPosition(context));
+            result.Add(RenderModuleWidth());
             result.Add($"^B2{RenderFieldOrientation()},{context.Scale(Height)},{RenderPrintInterpretationLine()},{RenderPrintInterpretationLineAboveCode()},{(Mod10CheckDigit ? "Y" : "N")}");
             result.Add($"^FD{Content}^FS");
 


### PR DESCRIPTION
Added the ModuleWidth Operator (^BY) to all 1D Barcodes.
The corresponding property was already implemented but not evaluated for rendering.