### PR TITLE
Add better support for QR Codes

### DIFF
--- a/src/BinaryKits.Zpl.Label/BinaryKits.Zpl.Label.csproj
+++ b/src/BinaryKits.Zpl.Label/BinaryKits.Zpl.Label.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net472;netstandard2.0;net6.0</TargetFrameworks>
     <Description>This package allows you to simply and reliably prepare labels complying with the Zebra programming language, using predefined class/typing. It also supports you with image conversion.</Description>
     <Company>Binary Kits Pte. Ltd.</Company>
-    <Version>3.1.3</Version>
+    <Version>3.1.4</Version>
     <Authors>Binary Kits Pte. Ltd.</Authors>
     <PackageReleaseNotes></PackageReleaseNotes>
     <PackageTags>Zebra ZPL ZPL2 Printer Label</PackageTags>

--- a/src/BinaryKits.Zpl.Label/Elements/ZplQrCode.cs
+++ b/src/BinaryKits.Zpl.Label/Elements/ZplQrCode.cs
@@ -11,7 +11,10 @@ namespace BinaryKits.Zpl.Label.Elements
         public int MagnificationFactor { get; private set; }
 
         public ErrorCorrectionLevel ErrorCorrectionLevel { get; private set; }
+
         public int MaskValue { get; private set; }
+
+        public FieldOrientation FieldOrientation { get; protected set; }
 
         /// <summary>
         /// Zpl QrCode
@@ -30,14 +33,22 @@ namespace BinaryKits.Zpl.Label.Elements
             int model = 2,
             int magnificationFactor = 2,
             ErrorCorrectionLevel errorCorrectionLevel = ErrorCorrectionLevel.HighReliability,
-            int maskValue = 7)
-            : base(positionX, positionY)
+            int maskValue = 7,
+            FieldOrientation fieldOrientation = FieldOrientation.Normal,
+            bool bottomToTop = false)
+            : base(positionX, positionY, bottomToTop)
         {
             Content = content;
             Model = model;
             MagnificationFactor = magnificationFactor;
             ErrorCorrectionLevel = errorCorrectionLevel;
             MaskValue = maskValue;
+            FieldOrientation = fieldOrientation;
+        }
+
+        protected string RenderFieldOrientation()
+        {
+            return RenderFieldOrientation(FieldOrientation);
         }
 
         ///<inheritdoc/>
@@ -48,7 +59,7 @@ namespace BinaryKits.Zpl.Label.Elements
             //^ FDMM,AAC - 42 ^ FS
             var result = new List<string>();
             result.AddRange(RenderPosition(context));
-            result.Add($"^BQN,{Model},{context.Scale(MagnificationFactor)},{RenderErrorCorrectionLevel(ErrorCorrectionLevel)},{MaskValue}");
+            result.Add($"^BQ{RenderFieldOrientation()},{Model},{context.Scale(MagnificationFactor)},{RenderErrorCorrectionLevel(ErrorCorrectionLevel)},{MaskValue}");
             result.Add($"^FD{RenderErrorCorrectionLevel(ErrorCorrectionLevel)}A,{Content}^FS");
 
             return result;

--- a/src/BinaryKits.Zpl.Label/Elements/ZplQrCode.cs
+++ b/src/BinaryKits.Zpl.Label/Elements/ZplQrCode.cs
@@ -26,6 +26,8 @@ namespace BinaryKits.Zpl.Label.Elements
         /// <param name="magnificationFactor">Size of the QR code, 1 on 150 dpi printers, 2 on 200 dpi printers, 3 on 300 dpi printers, 6 on 600 dpi printers</param>
         /// <param name="errorCorrectionLevel"></param>
         /// <param name="maskValue">0-7, (default: 7)</param>
+        ///  <param name="fieldOrientation"></param>
+        /// <param name="bottomToTop"></param>
         public ZplQrCode(
             string content,
             int positionX,

--- a/src/BinaryKits.Zpl.Viewer/BinaryKits.Zpl.Viewer.csproj
+++ b/src/BinaryKits.Zpl.Viewer/BinaryKits.Zpl.Viewer.csproj
@@ -23,7 +23,6 @@
 
   <ItemGroup>
     <PackageReference Include="BarcodeLib" Version="2.4.0" />
-    <PackageReference Include="QRCoder" Version="1.4.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
     <PackageReference Include="SkiaSharp" Version="2.80.3" />
     <PackageReference Include="ZXing.Net" Version="0.16.8" />

--- a/src/BinaryKits.Zpl.Viewer/BinaryKits.Zpl.Viewer.csproj
+++ b/src/BinaryKits.Zpl.Viewer/BinaryKits.Zpl.Viewer.csproj
@@ -23,7 +23,7 @@
 
   <ItemGroup>
     <PackageReference Include="BarcodeLib" Version="2.4.0" />
-    <PackageReference Include="QRCoder" Version="1.4.1" />
+    <PackageReference Include="QRCoder" Version="1.4.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
     <PackageReference Include="SkiaSharp" Version="2.80.3" />
     <PackageReference Include="ZXing.Net" Version="0.16.8" />

--- a/src/BinaryKits.Zpl.Viewer/BinaryKits.Zpl.Viewer.csproj
+++ b/src/BinaryKits.Zpl.Viewer/BinaryKits.Zpl.Viewer.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net472;netstandard2.0;net6.0</TargetFrameworks>
     <Description>This package provides a rendering logic for ZPL data, as an alternative to labelary.com.</Description>
     <Company>Binary Kits Pte. Ltd.</Company>
-    <Version>1.1.3</Version>
+    <Version>1.1.4</Version>
     <Authors>Binary Kits Pte. Ltd.</Authors>
     <PackageReleaseNotes></PackageReleaseNotes>
     <PackageTags>Zebra ZPL ZPL2 ZPLEmulator ZPLVirtualPrinter ZPLViewer ZPLParser</PackageTags>

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/QrCodeBarcodeZplCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/QrCodeBarcodeZplCommandAnalyzer.cs
@@ -35,21 +35,7 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
             }
             if (zplDataParts.Length > 3)
             {
-                switch (zplDataParts[3])
-                {
-                    case "H":
-                        errorCorrection = ErrorCorrectionLevel.UltraHighReliability;
-                        break;
-                    case "Q":
-                        errorCorrection = ErrorCorrectionLevel.HighReliability;
-                        break;
-                    case "M":
-                        errorCorrection = ErrorCorrectionLevel.Standard;
-                        break;
-                    case "L":
-                        errorCorrection = ErrorCorrectionLevel.HighDensity;
-                        break;
-                }
+                errorCorrection = this.ConvertErrorCorrectionLevel(zplDataParts[3]);
             }
             if (zplDataParts.Length > 4)
             {

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/ZplCommandAnalyzerBase.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/ZplCommandAnalyzerBase.cs
@@ -29,19 +29,26 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
 
         protected FieldOrientation ConvertFieldOrientation(string fieldOrientation)
         {
-            switch (fieldOrientation)
+            return fieldOrientation switch
             {
-                case "N":
-                    return FieldOrientation.Normal;
-                case "R":
-                    return FieldOrientation.Rotated90;
-                case "I":
-                    return FieldOrientation.Rotated180;
-                case "B":
-                    return FieldOrientation.Rotated270;
-            }
+                "N" => FieldOrientation.Normal,
+                "R" => FieldOrientation.Rotated90,
+                "I" => FieldOrientation.Rotated180,
+                "B" => FieldOrientation.Rotated270,
+                 _  => FieldOrientation.Normal,
+            };
+        }
 
-            return FieldOrientation.Normal;
+        protected ErrorCorrectionLevel ConvertErrorCorrectionLevel(string errorCorrection)
+        {
+            return errorCorrection switch
+            {
+                "H" => ErrorCorrectionLevel.UltraHighReliability,
+                "Q" => ErrorCorrectionLevel.HighReliability,
+                "M" => ErrorCorrectionLevel.Standard,
+                "L" => ErrorCorrectionLevel.HighDensity,
+                 _  => ErrorCorrectionLevel.Standard,
+            };
         }
 
         protected bool ConvertBoolean(string yesOrNo, string defaultValue = "N")

--- a/src/BinaryKits.Zpl.Viewer/ElementDrawers/BarcodeDrawerBase.cs
+++ b/src/BinaryKits.Zpl.Viewer/ElementDrawers/BarcodeDrawerBase.cs
@@ -1,6 +1,8 @@
 using SkiaSharp;
 using System.Drawing;
+using System.Drawing.Imaging;
 using System.IO;
+using ZXing.Common;
 
 namespace BinaryKits.Zpl.Viewer.ElementDrawers
 {
@@ -10,7 +12,7 @@ namespace BinaryKits.Zpl.Viewer.ElementDrawers
         {
             using (var memoryStream = new MemoryStream())
             {
-                image.Save(memoryStream, System.Drawing.Imaging.ImageFormat.Png);
+                image.Save(memoryStream, ImageFormat.Png);
                 return memoryStream.ToArray();
             }
         }
@@ -72,8 +74,24 @@ namespace BinaryKits.Zpl.Viewer.ElementDrawers
                     this._skCanvas.SetMatrix(matrix);
                 }
 
-                this._skCanvas.DrawBitmap(SKBitmap.Decode(barcodeImageData), x, y );
+                this._skCanvas.DrawBitmap(SKBitmap.Decode(barcodeImageData), x, y);
             }
+        }
+
+        protected SKBitmap BitMatrixToSKBitmap(BitMatrix matrix, int pixelScale)
+        {
+            using var image = new SKBitmap(matrix.Width, matrix.Height);
+
+            for (int row = 0; row < matrix.Height; row++)
+            {
+                for (int col = 0; col < matrix.Width; col++)
+                {
+                    var color = matrix[col, row] ? SKColors.Black : SKColors.Transparent;
+                    image.SetPixel(col, row, color);
+                }
+            }
+
+            return image.Resize(new SKSizeI(image.Width * pixelScale, image.Height * pixelScale), SKFilterQuality.None);
         }
     }
 }

--- a/src/BinaryKits.Zpl.Viewer/ElementDrawers/DataMatrixElementDrawer.cs
+++ b/src/BinaryKits.Zpl.Viewer/ElementDrawers/DataMatrixElementDrawer.cs
@@ -29,19 +29,7 @@ namespace BinaryKits.Zpl.Viewer.ElementDrawers
                 };
                 var result = writer.encode(dataMatrix.Content, BarcodeFormat.DATA_MATRIX, 0, 0, hints);
 
-                int size = dataMatrix.Height;
-                using var image = new SKBitmap(result.Width, result.Height);
-
-                for (int row = 0; row < result.Height; row++)
-                {
-                    for (int col = 0; col < result.Width; col++)
-                    {
-                        var color = result[col, row] ? SKColors.Black : SKColors.White;
-                        image.SetPixel(col, row, color);
-                    }
-                }
-
-                using var resizedImage = image.Resize(new SKSizeI(image.Width * size, image.Height * size), SKFilterQuality.None);
+                using var resizedImage = this.BitMatrixToSKBitmap(result, dataMatrix.Height);
 
                 var png = resizedImage.Encode(SKEncodedImageFormat.Png, 100).ToArray();
                 this.DrawBarcode(png, resizedImage.Height, resizedImage.Width, dataMatrix.FieldOrigin != null, x, y, 0, dataMatrix.FieldOrientation);

--- a/src/BinaryKits.Zpl.Viewer/ElementDrawers/DrawerOptions.cs
+++ b/src/BinaryKits.Zpl.Viewer/ElementDrawers/DrawerOptions.cs
@@ -7,6 +7,10 @@ namespace BinaryKits.Zpl.Viewer.ElementDrawers
     {
         public Func<string, SKTypeface> FontLoader { get; set; } = DefaultFontLoader;
 
+        public SKEncodedImageFormat RenderFormat { get; set; } = SKEncodedImageFormat.Png;
+
+        public int RenderQuality { get; set; } = 80;
+
         public static Func<string, SKTypeface> DefaultFontLoader = fontName => {
             var typeface = SKTypeface.Default;
             if (fontName == "0")

--- a/src/BinaryKits.Zpl.Viewer/ElementDrawers/QrCodeElementDrawer.cs
+++ b/src/BinaryKits.Zpl.Viewer/ElementDrawers/QrCodeElementDrawer.cs
@@ -16,7 +16,6 @@ namespace BinaryKits.Zpl.Viewer.ElementDrawers
         }
 
         ///<inheritdoc/>
-        ///<todo
         public override void Draw(ZplElementBase element)
         {
             if (element is ZplQrCode qrcode)

--- a/src/BinaryKits.Zpl.Viewer/ZplElementDrawer.cs
+++ b/src/BinaryKits.Zpl.Viewer/ZplElementDrawer.cs
@@ -95,12 +95,12 @@ namespace BinaryKits.Zpl.Viewer
                     }
                     else
                     {
-                        throw ex;
+                        throw;
                     }
                 }
             }
 
-            using var data = skBitmap.Encode(SKEncodedImageFormat.Png, 80);
+            using var data = skBitmap.Encode(_drawerOptions.RenderFormat, _drawerOptions.RenderQuality);
             return data.ToArray();
         }
 


### PR DESCRIPTION
- Implement `^FT` Positioning (#142)
- Implement Error Correction (#67)
- Parse FieldData correctly for Normal Mode and Mixed Mode
- Add RenderFormat and RenderQuality to DrawerOptions (#141)
- Remove QRCoder dependency

Known Issues:
---
- Data Mode is parsed, but not respected. The ZXing library is allowed to choose the data mode automatically.
- Mixed Mode support is limited. The number of divisions and parity byte are not verified. The data mode of individual sections is ignored, and encoded as a single section. The ZXing library supports GS1 style codes, but this is not utilized.

Tests:
---
`^FT` positioning (#142):
```zpl
^XA
^FT20,122^BQ,2,3
^FH^FDLA,123456789012^FS
^FT111,52^A0N,23,23^FH^FDTest^FS
^XZ
```
<img src="https://user-images.githubusercontent.com/4907320/203779652-d32d6102-185a-45e7-bcc8-e521810d1a0d.png" width="400" />

---
Normal Mode with Automatic Data Input, at various Error Correction Levels (#67):
```zpl
^XA
^FO20,20^BQ,2,10^FDHA,BinaryKits.Zpl.Viewer^FS
^FO400,20^BQ,2,10^FDQA,BinaryKits.Zpl.Viewer^FS
^FO20,400^BQ,2,10^FDMA,BinaryKits.Zpl.Viewer^FS
^FO400,400^BQ,2,10^FDLA,BinaryKits.Zpl.Viewer^FS
^XZ
```
<img src="https://user-images.githubusercontent.com/4907320/203779881-1dbd8672-8944-42e0-bb00-b66465b75731.png" width="400" />

---
Normal Mode with Manual Data Input:
```zpl
^XA
^FO20,20^BQ,2,10
^FDHM,N123456789012345^FS
^XZ
```
<img src="https://user-images.githubusercontent.com/4907320/203780088-0cdcd3fc-b044-49cd-a744-25c23524d975.png" width="400" />

Expected: `123456789012345` without leading `N`.

---
Mixed Mode with Manual Data Input:
```zpl
^XA
^FO20,20^BQ,2,10
^FDD03040C,LM,N0123456789,A12AABB,B0006qrcode^FS
^XZ
```
<img src="https://user-images.githubusercontent.com/4907320/203780410-fea93634-5f56-4e91-87c8-1db04728967a.png" width="400" />

Expected: `012345678912AABBqrcode`.

---
Mixed Mode with Automatic Data Input:
```zpl
^XA
^FO20,20^BQ,2,10
^FDD03040C,LA,0123456789,12AABB,qrcode^FS
^XZ
```
Output is identical to the previous test.

---
Normal Mode with Manual Data Input, having Kanji Character Mode:
```zpl
^XA
^FO20,20^BQ,2,10
^FDLM,K漢字^FS
^XZ
```
<img src="https://user-images.githubusercontent.com/4907320/203780834-fdd22300-416c-4d13-8c7e-1f1f93cdd0fc.png" width="400" />

Expected: `漢字`.

---
Normal Mode with Automatic Data Input, with various Mask Values:
```zpl
^XA
^FO20,20^BQ,2,5,Q,0^FDQA,0123456789ABCD^FS
^FO142,20^BQ,2,5,Q,1^FDQA,0123456789ABCD^FS
^FO264,20^BQ,2,5,Q,2^FDQA,0123456789ABCD^FS
^FO386,20^BQ,2,5,Q,3^FDQA,0123456789ABCD^FS
^FO20,142^BQ,2,5,Q,4^FDQA,0123456789ABCD^FS
^FO142,142^BQ,2,5,Q,5^FDQA,0123456789ABCD^FS
^FO264,142^BQ,2,5,Q,6^FDQA,0123456789ABCD^FS
^FO386,142^BQ,2,5,Q,7^FDQA,0123456789ABCD^FS
^XZ
```
<img src="https://user-images.githubusercontent.com/4907320/203782219-0a1de8f0-6509-44ff-a752-3b8cdad185bf.png" width="400" />

Expected: `0123456789ABCD` for all.
