### PR TITLE
Increment Version Numbers

### DIFF
--- a/src/BinaryKits.Zpl.Label/BinaryKits.Zpl.Label.csproj
+++ b/src/BinaryKits.Zpl.Label/BinaryKits.Zpl.Label.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net472;netstandard2.0;net6.0</TargetFrameworks>
     <Description>This package allows you to simply and reliably prepare labels complying with the Zebra programming language, using predefined class/typing. It also supports you with image conversion.</Description>
     <Company>Binary Kits Pte. Ltd.</Company>
-    <Version>3.1.4</Version>
+    <Version>3.1.5</Version>
     <Authors>Binary Kits Pte. Ltd.</Authors>
     <PackageReleaseNotes></PackageReleaseNotes>
     <PackageTags>Zebra ZPL ZPL2 Printer Label</PackageTags>

--- a/src/BinaryKits.Zpl.Viewer/BinaryKits.Zpl.Viewer.csproj
+++ b/src/BinaryKits.Zpl.Viewer/BinaryKits.Zpl.Viewer.csproj
@@ -23,7 +23,6 @@
 
   <ItemGroup>
     <PackageReference Include="BarcodeLib" Version="2.4.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
     <PackageReference Include="SkiaSharp" Version="2.88.3" />
     <PackageReference Include="SkiaSharp.HarfBuzz" Version="2.88.3" />
     <PackageReference Include="ZXing.Net" Version="0.16.9" />

--- a/src/BinaryKits.Zpl.Viewer/BinaryKits.Zpl.Viewer.csproj
+++ b/src/BinaryKits.Zpl.Viewer/BinaryKits.Zpl.Viewer.csproj
@@ -31,6 +31,7 @@
 
   <ItemGroup Condition="$([MSBuild]::IsOSPlatform('Linux'))">
     <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="2.88.3" />
+    <PackageReference Include="HarfBuzzSharp.NativeAssets.Linux" Version="2.8.2.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BinaryKits.Zpl.Viewer/BinaryKits.Zpl.Viewer.csproj
+++ b/src/BinaryKits.Zpl.Viewer/BinaryKits.Zpl.Viewer.csproj
@@ -24,13 +24,13 @@
   <ItemGroup>
     <PackageReference Include="BarcodeLib" Version="2.4.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
-    <PackageReference Include="SkiaSharp" Version="2.80.3" />
-    <PackageReference Include="SkiaSharp.HarfBuzz" Version="2.80.3" />
-    <PackageReference Include="ZXing.Net" Version="0.16.8" />
+    <PackageReference Include="SkiaSharp" Version="2.88.3" />
+    <PackageReference Include="SkiaSharp.HarfBuzz" Version="2.88.3" />
+    <PackageReference Include="ZXing.Net" Version="0.16.9" />
   </ItemGroup>
 
   <ItemGroup Condition="$([MSBuild]::IsOSPlatform('Linux'))">
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="2.80.3" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="2.88.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BinaryKits.Zpl.Viewer/BinaryKits.Zpl.Viewer.csproj
+++ b/src/BinaryKits.Zpl.Viewer/BinaryKits.Zpl.Viewer.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net472;netstandard2.0;net6.0</TargetFrameworks>
     <Description>This package provides a rendering logic for ZPL data, as an alternative to labelary.com.</Description>
     <Company>Binary Kits Pte. Ltd.</Company>
-    <Version>1.1.4</Version>
+    <Version>1.1.5</Version>
     <Authors>Binary Kits Pte. Ltd.</Authors>
     <PackageReleaseNotes></PackageReleaseNotes>
     <PackageTags>Zebra ZPL ZPL2 ZPLEmulator ZPLVirtualPrinter ZPLViewer ZPLParser</PackageTags>


### PR DESCRIPTION
Changes from previous versions:

BinaryKits.Zpl.Label
- Prevent InvalidCastException when the target image for DownloadGraphics or GraphicField is not a PNG32.

BinaryKits.Zpl.Viewer
- Parse DeviceName and Extension for DownloadFormat.
- Trim leading spaces for most commands.
- Improved InverseDraw to maintain true type font fidelity.
- Add `ReplaceDashWithEnDash` option to DrawerOptions (default `true`)
- Change default font `0` to Helvetica Bold Narrow, DejaVu Sans Mono for all others.
- Change default label size to be exactly 6"x4", rather than an approximation.
- Add support for rendering RTL languages.
- Bump SkiaSharp and ZXing dependencies.