### PR TITLE
Preserve numeric defaults in command analyzers

### DIFF
--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/BarCodeFieldDefaultZplCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/BarCodeFieldDefaultZplCommandAnalyzer.cs
@@ -4,30 +4,37 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
 {
     public class BarCodeFieldDefaultZplCommandAnalyzer : ZplCommandAnalyzerBase
     {
-        public BarCodeFieldDefaultZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^BY", virtualPrinter)
-        { }
+        public BarCodeFieldDefaultZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^BY", virtualPrinter) { }
 
+        ///<inheritdoc/>
         public override ZplElementBase Analyze(string zplCommand)
         {
             var zplDataParts = this.SplitCommand(zplCommand);
 
-            if (zplDataParts.Length > 0)
+            int tmpint;
+            double tmpdbl;
+            int moduleWidth = 2;
+            double wideBarToNarrowBarWidthRatio = 3.0;
+            int barcodeHeight = 10;
+
+            if (zplDataParts.Length > 0 && int.TryParse(zplDataParts[0], out tmpint))
             {
-                _ = int.TryParse(zplDataParts[0], out var moduleWidth);
-                this.VirtualPrinter.SetBarcodeModuleWidth(moduleWidth);
+                moduleWidth = tmpint;
             }
 
-            if (zplDataParts.Length > 1)
+            if (zplDataParts.Length > 1 && double.TryParse(zplDataParts[1], out tmpdbl))
             {
-                _ = double.TryParse(zplDataParts[1], out var wideBarToNarrowBarWidthRatio);
-                this.VirtualPrinter.SetBarcodeWideBarToNarrowBarWidthRatio(wideBarToNarrowBarWidthRatio);
+                wideBarToNarrowBarWidthRatio = tmpdbl;
             }
 
-            if (zplDataParts.Length > 2)
+            if (zplDataParts.Length > 2 && int.TryParse(zplDataParts[2], out tmpint))
             {
-                _ = int.TryParse(zplDataParts[2], out var barcodeHeight);
-                this.VirtualPrinter.SetBarcodeHeight(barcodeHeight);
+                barcodeHeight = tmpint;
             }
+
+            this.VirtualPrinter.SetBarcodeModuleWidth(moduleWidth);
+            this.VirtualPrinter.SetBarcodeWideBarToNarrowBarWidthRatio(wideBarToNarrowBarWidthRatio);
+            this.VirtualPrinter.SetBarcodeHeight(barcodeHeight);
 
             return null;
         }

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/ChangeAlphanumericDefaultFontZplCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/ChangeAlphanumericDefaultFontZplCommandAnalyzer.cs
@@ -4,21 +4,27 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
 {
     public class ChangeAlphanumericDefaultFontZplCommandAnalyzer : ZplCommandAnalyzerBase
     {
-        public ChangeAlphanumericDefaultFontZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^CF", virtualPrinter)
-        { }
+        public ChangeAlphanumericDefaultFontZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^CF", virtualPrinter) { }
 
+        ///<inheritdoc/>
         public override ZplElementBase Analyze(string zplCommand)
         {
             var zplDataParts = this.SplitCommand(zplCommand);
 
             this.VirtualPrinter.SetFontName(zplDataParts[0]);
 
-            var fontWidth = 0;
+            int tmpint;
+            int fontHeight = 9;
+            int fontWidth = 0;
 
-            _ = int.TryParse(zplDataParts[1], out var fontHeight);
-            if (zplDataParts.Length > 2)
+            if (zplDataParts.Length > 1 && int.TryParse(zplDataParts[1], out tmpint))
             {
-                _ = int.TryParse(zplDataParts[2], out fontWidth);
+                fontHeight = tmpint;
+            }
+
+            if (zplDataParts.Length > 2 && int.TryParse(zplDataParts[2], out tmpint))
+            {
+                fontWidth = tmpint;
             }
 
             this.VirtualPrinter.SetFontHeight(fontHeight);

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/Code128BarcodeZplCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/Code128BarcodeZplCommandAnalyzer.cs
@@ -5,39 +5,42 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
 {
     public class Code128BarcodeZplCommandAnalyzer : ZplCommandAnalyzerBase
     {
-        public Code128BarcodeZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^BC", virtualPrinter)
-        { }
+        public Code128BarcodeZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^BC", virtualPrinter) { }
 
+        ///<inheritdoc/>
         public override ZplElementBase Analyze(string zplCommand)
         {
             var zplDataParts = this.SplitCommand(zplCommand);
 
             var fieldOrientation = this.ConvertFieldOrientation(zplDataParts[0]);
-            var height = this.VirtualPrinter.BarcodeInfo.Height;
-            var printInterpretationLine = true;
-            var printInterpretationLineAboveCode = false;
-            var uccCheckDigit = false;
-            var mode = "N";
 
-            if (zplDataParts.Length > 1)
+            int tmpint;
+            int height = this.VirtualPrinter.BarcodeInfo.Height;
+            bool printInterpretationLine = true;
+            bool printInterpretationLineAboveCode = false;
+            bool uccCheckDigit = false;
+            string mode = "N";
+
+            if (zplDataParts.Length > 1 && int.TryParse(zplDataParts[1], out tmpint))
             {
-                if(!string.IsNullOrEmpty(zplDataParts[1]))
-                {
-                    _ = int.TryParse(zplDataParts[1], out height);
-                }
+                height = tmpint;
             }
+
             if (zplDataParts.Length > 2)
             {
                 printInterpretationLine = this.ConvertBoolean(zplDataParts[2], "Y");
             }
+
             if (zplDataParts.Length > 3)
             {
                 printInterpretationLineAboveCode = this.ConvertBoolean(zplDataParts[3]);
             }
+
             if (zplDataParts.Length > 4)
             {
                 uccCheckDigit = this.ConvertBoolean(zplDataParts[4]);
             }
+
             if (zplDataParts.Length > 5)
             {
                 mode = zplDataParts[5];

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/Code39BarcodeZplCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/Code39BarcodeZplCommandAnalyzer.cs
@@ -5,34 +5,35 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
 {
     public class Code39BarcodeZplCommandAnalyzer : ZplCommandAnalyzerBase
     {
-        public Code39BarcodeZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^B3", virtualPrinter)
-        { }
+        public Code39BarcodeZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^B3", virtualPrinter) { }
 
+        ///<inheritdoc/>
         public override ZplElementBase Analyze(string zplCommand)
         {
             var zplDataParts = this.SplitCommand(zplCommand);
 
-            var mod43CheckDigit = false;
-            var height = this.VirtualPrinter.BarcodeInfo.Height;
-            var printInterpretationLine = true;
-            var printInterpretationLineAboveCode = false;
+            int tmpint;
+            bool mod43CheckDigit = false;
+            int height = this.VirtualPrinter.BarcodeInfo.Height;
+            bool printInterpretationLine = true;
+            bool printInterpretationLineAboveCode = false;
 
             var fieldOrientation = this.ConvertFieldOrientation(zplDataParts[0]);
             if (zplDataParts.Length > 1)
             {
                 mod43CheckDigit = this.ConvertBoolean(zplDataParts[1]);
             }
-            if (zplDataParts.Length > 2)
+
+            if (zplDataParts.Length > 2 && int.TryParse(zplDataParts[2], out tmpint))
             {
-                if (!string.IsNullOrEmpty(zplDataParts[2]))
-                {
-                    _ = int.TryParse(zplDataParts[2], out height);
-                }
+                height = tmpint;
             }
+
             if (zplDataParts.Length > 3)
             {
                 printInterpretationLine = this.ConvertBoolean(zplDataParts[3], "Y");
             }
+
             if (zplDataParts.Length > 4)
             {
                 printInterpretationLineAboveCode = this.ConvertBoolean(zplDataParts[4]);

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/CodeEAN13BarcodeZplCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/CodeEAN13BarcodeZplCommandAnalyzer.cs
@@ -5,34 +5,34 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
 {
     public class CodeEAN13BarcodeZplCommandAnalyzer : ZplCommandAnalyzerBase
     {
-        public CodeEAN13BarcodeZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^BE", virtualPrinter)
-        { }
+        public CodeEAN13BarcodeZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^BE", virtualPrinter) { }
 
+        ///<inheritdoc/>
         public override ZplElementBase Analyze(string zplCommand)
         {
             var zplDataParts = this.SplitCommand(zplCommand);
 
             var fieldOrientation = this.ConvertFieldOrientation(zplDataParts[0]);
-            var height = this.VirtualPrinter.BarcodeInfo.Height;
-            var printInterpretationLine = true;
-            var printInterpretationLineAboveCode = false;
 
-            if (zplDataParts.Length > 1)
+            int tmpint;
+            int height = this.VirtualPrinter.BarcodeInfo.Height;
+            bool printInterpretationLine = true;
+            bool printInterpretationLineAboveCode = false;
+
+            if (zplDataParts.Length > 1 && int.TryParse(zplDataParts[1], out tmpint))
             {
-                if (!string.IsNullOrEmpty(zplDataParts[1]))
-                {
-                    _ = int.TryParse(zplDataParts[1], out height);
-                }
+                height = tmpint;
             }
+
             if (zplDataParts.Length > 2)
             {
                 printInterpretationLine = this.ConvertBoolean(zplDataParts[2], "Y");
             }
+
             if (zplDataParts.Length > 3)
             {
                 printInterpretationLineAboveCode = this.ConvertBoolean(zplDataParts[3]);
             }
-          
 
             //The field data are processing in the FieldDataZplCommandAnalyzer
             this.VirtualPrinter.SetNextElementFieldData(new CodeEAN13BarcodeFieldData

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/CommentZplCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/CommentZplCommandAnalyzer.cs
@@ -4,12 +4,12 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
 {
     public class CommentZplCommandAnalyzer : ZplCommandAnalyzerBase
     {
-        public CommentZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^FX", virtualPrinter)
-        { }
+        public CommentZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^FX", virtualPrinter) { }
 
+        ///<inheritdoc/>
         public override ZplElementBase Analyze(string zplCommand)
         {
-            var comment = zplCommand.Substring(this.PrinterCommandPrefix.Length);
+            string comment = zplCommand.Substring(this.PrinterCommandPrefix.Length);
             this.VirtualPrinter.AddComment(comment);
 
             return null;

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/DataMatrixZplCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/DataMatrixZplCommandAnalyzer.cs
@@ -5,22 +5,21 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
 {
     public class DataMatrixZplCommandAnalyzer : ZplCommandAnalyzerBase
     {
-        public DataMatrixZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^BX", virtualPrinter)
-        { }
+        public DataMatrixZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^BX", virtualPrinter) { }
 
+        ///<inheritdoc/>
         public override ZplElementBase Analyze(string zplCommand)
         {
             var zplDataParts = this.SplitCommand(zplCommand);
 
             var fieldOrientation = this.ConvertFieldOrientation(zplDataParts[0]);
-            var height = this.VirtualPrinter.BarcodeInfo.Height;
 
-            if (zplDataParts.Length > 1)
+            int tmpint;
+            int height = this.VirtualPrinter.BarcodeInfo.Height;
+
+            if (zplDataParts.Length > 1 && int.TryParse(zplDataParts[1], out tmpint))
             {
-                if (!string.IsNullOrEmpty(zplDataParts[1]))
-                {
-                    _ = int.TryParse(zplDataParts[1], out height);
-                }
+                height = tmpint;
             }
 
             //The field data are processing in the FieldDataZplCommandAnalyzer

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/DownloadFormatCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/DownloadFormatCommandAnalyzer.cs
@@ -7,16 +7,16 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
     {
         private static readonly Regex commandRegex = new Regex(@"^\^DF(\w:)?(.*?)?(\..+?)?$", RegexOptions.Compiled);
 
-        public DownloadFormatCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^DF", virtualPrinter)
-        { }
+        public DownloadFormatCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^DF", virtualPrinter) { }
 
+        ///<inheritdoc/>
         public override ZplElementBase Analyze(string zplCommand)
         {
             var commandMatch = commandRegex.Match(zplCommand);
             if (commandMatch.Success)
             {
-                var storageDevice = commandMatch.Groups[1].Success ? commandMatch.Groups[1].Value[0] : 'R';
-                var formatName = commandMatch.Groups[2].Value;
+                char storageDevice = commandMatch.Groups[1].Success ? commandMatch.Groups[1].Value[0] : 'R';
+                string formatName = commandMatch.Groups[2].Value;
 
                 this.VirtualPrinter.SetNextDownloadFormatName(formatName);
             }

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/DownloadGraphicsZplCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/DownloadGraphicsZplCommandAnalyzer.cs
@@ -10,26 +10,26 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
     public class DownloadGraphicsZplCommandAnalyzer : ZplCommandAnalyzerBase
     {
         private static readonly Regex commandRegex = new Regex( @"^~DG(\w:)?(.*?\..+?),(\d+),(\d+),(.+)$",RegexOptions.Compiled);
+
         private readonly IPrinterStorage _printerStorage;
 
-        public DownloadGraphicsZplCommandAnalyzer(
-            VirtualPrinter virtualPrinter, 
-            IPrinterStorage printerStorage) 
-            : base("~DG",virtualPrinter)
-        { 
-            this._printerStorage = printerStorage; 
+        public DownloadGraphicsZplCommandAnalyzer(VirtualPrinter virtualPrinter, IPrinterStorage printerStorage)
+            : base("~DG", virtualPrinter)
+        {
+            this._printerStorage = printerStorage;
         }
 
+        ///<inheritdoc/>
         public override ZplElementBase Analyze(string zplCommand)
         {
             var commandMatch = commandRegex.Match(zplCommand);
             if (commandMatch.Success)
             {
-                var storageDevice = commandMatch.Groups[1].Success ? commandMatch.Groups[1].Value[0] : 'R';
-                var imageName = commandMatch.Groups[2].Value;
-                _ = int.TryParse(commandMatch.Groups[3].Value, out var totalNumberOfBytesInGraphic);
-                _ = int.TryParse(commandMatch.Groups[4].Value, out var numberOfBytesPerRow);
-                var dataHex = commandMatch.Groups[5].Value;
+                char storageDevice = commandMatch.Groups[1].Success ? commandMatch.Groups[1].Value[0] : 'R';
+                string imageName = commandMatch.Groups[2].Value;
+                _ = int.TryParse(commandMatch.Groups[3].Value, out int totalNumberOfBytesInGraphic);
+                _ = int.TryParse(commandMatch.Groups[4].Value, out int numberOfBytesPerRow);
+                string dataHex = commandMatch.Groups[5].Value;
 
                 byte[] grfImageData = ImageHelper.GetImageBytes(dataHex, numberOfBytesPerRow);
 

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/DownloadObjectsZplCommandAnaylzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/DownloadObjectsZplCommandAnaylzer.cs
@@ -8,28 +8,27 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
     {
         private readonly IPrinterStorage _printerStorage;
 
-        public DownloadObjectsZplCommandAnaylzer(
-            VirtualPrinter virtualPrinter,
-            IPrinterStorage printerStorage)
+        public DownloadObjectsZplCommandAnaylzer(VirtualPrinter virtualPrinter, IPrinterStorage printerStorage)
             : base("~DY", virtualPrinter)
         {
             this._printerStorage = printerStorage;
         }
 
+        ///<inheritdoc/>
         public override ZplElementBase Analyze(string zplCommand)
         {
-            var storageDevice = zplCommand[this.PrinterCommandPrefix.Length];
+            char storageDevice = zplCommand[this.PrinterCommandPrefix.Length];
 
             var zplDataParts = this.SplitCommand(zplCommand, 2);
 
-            var objectName = zplDataParts[0];
-            var formatDownloadedInDataField = zplDataParts[1];
-            var extensionOfStoredFile = zplDataParts[2];
-            _ = int.TryParse(zplDataParts[3], out var objectDataLength);
-            _ = int.TryParse(zplDataParts[4], out var totalNumberOfBytesPerRow);
+            string objectName = zplDataParts[0];
+            string formatDownloadedInDataField = zplDataParts[1];
+            string extensionOfStoredFile = zplDataParts[2];
+            _ = int.TryParse(zplDataParts[3], out int objectDataLength);
+            _ = int.TryParse(zplDataParts[4], out int totalNumberOfBytesPerRow);
 
             //TODO: Handle case when .GRF data is downloaded using the ~DY command
-            var dataHex = zplDataParts[5];
+            string dataHex = zplDataParts[5];
 
             this._printerStorage.AddFile(storageDevice, objectName, ByteHelper.HexToBytes(dataHex));
 

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/FieldBlockZplCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/FieldBlockZplCommandAnalyzer.cs
@@ -9,28 +9,32 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
         public FieldBlockZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^FB", virtualPrinter)
         { }
 
+        ///<inheritdoc/>
         public override ZplElementBase Analyze(string zplCommand)
         {
             var zplDataParts = this.SplitCommand(zplCommand);
 
-            var widthOfTextBlockLine = 0;
-            var maximumNumberOfLinesInTextBlock = 1;
-            var addOrDeleteSpaceBetweenLines = 0;
+            int tmpint;
+            int widthOfTextBlockLine = 0;
+            int maximumNumberOfLinesInTextBlock = 1;
+            int addOrDeleteSpaceBetweenLines = 0;
             var textJustification = TextJustification.Left;
-            var hangingIndentOfTheSecondAndRemainingLines = 0;
+            int hangingIndentOfTheSecondAndRemainingLines = 0;
 
-            if (zplDataParts.Length > 0)
+            if (zplDataParts.Length > 0 && int.TryParse(zplDataParts[0], out tmpint))
             {
-                _ = int.TryParse(zplDataParts[0], out widthOfTextBlockLine);
+                widthOfTextBlockLine = tmpint;
             }
-            if (zplDataParts.Length > 1)
+
+            if (zplDataParts.Length > 1 && int.TryParse(zplDataParts[1], out tmpint))
             {
-                _ = int.TryParse(zplDataParts[1], out maximumNumberOfLinesInTextBlock);
+                maximumNumberOfLinesInTextBlock = tmpint;
             }
-            if (zplDataParts.Length > 2)
-            {
-                _ = int.TryParse(zplDataParts[2], out addOrDeleteSpaceBetweenLines);
+
+            if (zplDataParts.Length > 2 && int.TryParse(zplDataParts[2], out tmpint)) {
+                addOrDeleteSpaceBetweenLines = tmpint;
             }
+
             if (zplDataParts.Length > 3)
             {
                 switch (zplDataParts[3])
@@ -46,21 +50,19 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
                         break;
                 }
             }
-            if (zplDataParts.Length > 4)
-            {
-                _ = int.TryParse(zplDataParts[4], out hangingIndentOfTheSecondAndRemainingLines);
+
+            if (zplDataParts.Length > 4 && int.TryParse(zplDataParts[4], out tmpint)) {
+                hangingIndentOfTheSecondAndRemainingLines = tmpint;
             }
 
-            var fieldBlock = new FieldBlock
+            this.VirtualPrinter.SetNextElementFieldBlock(new FieldBlock
             {
                 WidthOfTextBlockLine = widthOfTextBlockLine,
                 MaximumNumberOfLinesInTextBlock = maximumNumberOfLinesInTextBlock,
                 AddOrDeleteSpaceBetweenLines = addOrDeleteSpaceBetweenLines,
                 TextJustification = textJustification,
                 HangingIndentOfTheSecondAndRemainingLines = hangingIndentOfTheSecondAndRemainingLines
-            };
-
-            this.VirtualPrinter.SetNextElementFieldBlock(fieldBlock);
+            });
 
             return null;
         }

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/FieldDataZplCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/FieldDataZplCommandAnalyzer.cs
@@ -16,12 +16,12 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
         private static readonly Regex qrCodeFieldDataMixedRegex = new Regex(@"^D\d{4}[0-9A-F-a-f]{2},(?<correction>[HQML])(?<input>[AM]),(?<data>.+)$", RegexOptions.Compiled);
         private static readonly Regex qrCodeFieldDataModeRegex = new Regex(@"^(?:[ANK]|(?:B(?<count>\d{4})))(?<data>.+)$", RegexOptions.Compiled);
 
-        public FieldDataZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^FD", virtualPrinter)
-        { }
+        public FieldDataZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^FD", virtualPrinter) { }
 
+        ///<inheritdoc/>
         public override ZplElementBase Analyze(string zplCommand)
         {
-            var text = zplCommand.Substring(this.PrinterCommandPrefix.Length);
+            string text = zplCommand.Substring(this.PrinterCommandPrefix.Length);
 
             // If field data follows a field number, a ZplRecallFieldNumber element has to be returned
             int? fieldNumber = this.VirtualPrinter.NextFieldNumber;
@@ -31,9 +31,9 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
                 return new ZplRecallFieldNumber(fieldNumber.Value, text);
             }
 
-            var x = 0;
-            var y = 0;
-            var bottomToTop = false;
+            int x = 0;
+            int y = 0;
+            bool bottomToTop = false;
 
             if (this.VirtualPrinter.NextElementPosition != null)
             {
@@ -45,8 +45,8 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
 
             if (this.VirtualPrinter.NextElementFieldData != null)
             {
-                var moduleWidth = this.VirtualPrinter.BarcodeInfo.ModuleWidth;
-                var wideBarToNarrowBarWidthRatio = this.VirtualPrinter.BarcodeInfo.WideBarToNarrowBarWidthRatio;
+                int moduleWidth = this.VirtualPrinter.BarcodeInfo.ModuleWidth;
+                double wideBarToNarrowBarWidthRatio = this.VirtualPrinter.BarcodeInfo.WideBarToNarrowBarWidthRatio;
 
                 if (this.VirtualPrinter.NextElementFieldData is Code39BarcodeFieldData code39)
                 {
@@ -84,15 +84,15 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
                 font = this.GetNextFontFromVirtualPrinter();
             }
 
-            var reversePrint = this.VirtualPrinter.NextElementFieldReverse || this.VirtualPrinter.LabelReverse;
+            bool reversePrint = this.VirtualPrinter.NextElementFieldReverse || this.VirtualPrinter.LabelReverse;
 
             if (this.VirtualPrinter.NextElementFieldBlock != null)
             {
-                var width = this.VirtualPrinter.NextElementFieldBlock.WidthOfTextBlockLine;
-                var maxLineCount = this.VirtualPrinter.NextElementFieldBlock.MaximumNumberOfLinesInTextBlock;
+                int width = this.VirtualPrinter.NextElementFieldBlock.WidthOfTextBlockLine;
+                int maxLineCount = this.VirtualPrinter.NextElementFieldBlock.MaximumNumberOfLinesInTextBlock;
                 var textJustification = this.VirtualPrinter.NextElementFieldBlock.TextJustification;
-                var lineSpace = this.VirtualPrinter.NextElementFieldBlock.AddOrDeleteSpaceBetweenLines;
-                var hangingIndent = this.VirtualPrinter.NextElementFieldBlock.HangingIndentOfTheSecondAndRemainingLines;
+                int lineSpace = this.VirtualPrinter.NextElementFieldBlock.AddOrDeleteSpaceBetweenLines;
+                int hangingIndent = this.VirtualPrinter.NextElementFieldBlock.HangingIndentOfTheSecondAndRemainingLines;
 
                 return new ZplFieldBlock(text, x, y, width, font, maxLineCount, lineSpace, textJustification, hangingIndent, reversePrint : reversePrint, bottomToTop: bottomToTop);
             }
@@ -190,18 +190,18 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
 
         private ZplFont GetFontFromVirtualPrinter()
         {
-            var fontWidth = this.VirtualPrinter.FontWidth;
-            var fontHeight = this.VirtualPrinter.FontHeight;
-            var fontName = this.VirtualPrinter.FontName;
+            int fontWidth = this.VirtualPrinter.FontWidth;
+            int fontHeight = this.VirtualPrinter.FontHeight;
+            string fontName = this.VirtualPrinter.FontName;
 
             return new ZplFont(fontWidth, fontHeight, fontName);
         }
 
         private ZplFont GetNextFontFromVirtualPrinter()
         {
-            var fontWidth = this.VirtualPrinter.NextFont.FontWidth;
-            var fontHeight = this.VirtualPrinter.NextFont.FontHeight;
-            var fontName = this.VirtualPrinter.NextFont.FontName;
+            int fontWidth = this.VirtualPrinter.NextFont.FontWidth;
+            int fontHeight = this.VirtualPrinter.NextFont.FontHeight;
+            string fontName = this.VirtualPrinter.NextFont.FontName;
             var fieldOrientation = this.VirtualPrinter.NextFont.FieldOrientation;
 
             return new ZplFont(fontWidth, fontHeight, fontName, fieldOrientation);

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/FieldHexadecimalZplCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/FieldHexadecimalZplCommandAnalyzer.cs
@@ -5,8 +5,9 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
 {
     public class FieldHexadecimalZplCommandAnalyzer : ZplCommandAnalyzerBase
     {
-        public FieldHexadecimalZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^FH", virtualPrinter)
-        { }
+        public FieldHexadecimalZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^FH", virtualPrinter) { }
+
+        ///<inheritdoc/>
         public override ZplElementBase Analyze(string zplCommand)
         {
             var zplDataParts = this.SplitCommand(zplCommand);
@@ -17,7 +18,9 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
             {
                 Indicator = zplDataParts[0][0];
             }
+
             StringHelper.ReplaceChar = Indicator;
+
             return null;
         }
     }

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/FieldNumberCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/FieldNumberCommandAnalyzer.cs
@@ -4,16 +4,22 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
 {
     public class FieldNumberCommandAnalyzer : ZplCommandAnalyzerBase
     {
-        public FieldNumberCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^FN", virtualPrinter)
-        { }
+        public FieldNumberCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^FN", virtualPrinter) { }
 
+        ///<inheritdoc/>
         public override ZplElementBase Analyze(string zplCommand)
         {
             var zplDataParts = this.SplitCommand(zplCommand);
 
-            _ = int.TryParse(zplDataParts[0], out var number);
+            int tmpint;
+            int fieldNumber = 0;
 
-            this.VirtualPrinter.SetNextFieldNumber(number);
+            if (zplDataParts.Length > 0 && int.TryParse(zplDataParts[0], out tmpint))
+            {
+                fieldNumber = tmpint;
+            }
+
+            this.VirtualPrinter.SetNextFieldNumber(fieldNumber);
             return null;
         }
     }

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/FieldOriginZplCommandAnalzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/FieldOriginZplCommandAnalzer.cs
@@ -4,15 +4,28 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
 {
     public class FieldOriginZplCommandAnalzer : ZplCommandAnalyzerBase
     {
-        public FieldOriginZplCommandAnalzer(VirtualPrinter virtualPrinter) : base("^FO", virtualPrinter)
-        { }
+        public FieldOriginZplCommandAnalzer(VirtualPrinter virtualPrinter) : base("^FO", virtualPrinter) { }
 
+        ///<inheritdoc/>
         public override ZplElementBase Analyze(string zplCommand)
         {
             var zplDataParts = this.SplitCommand(zplCommand);
 
-            _ = int.TryParse(zplDataParts[0], out var x);
-            _ = int.TryParse(zplDataParts[1], out var y);
+            int tmpint;
+            int x = 0;
+            int y = 0;
+            // TODO: Field Justification
+            //int z = 0;
+
+            if (zplDataParts.Length > 0 && int.TryParse(zplDataParts[0], out tmpint))
+            {
+                x = tmpint;
+            }
+
+            if (zplDataParts.Length > 1 && int.TryParse(zplDataParts[1], out tmpint))
+            {
+                y = tmpint;
+            }
 
             if (this.VirtualPrinter.LabelHomePosition != null)
             {

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/FieldReversePrintZplCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/FieldReversePrintZplCommandAnalyzer.cs
@@ -4,9 +4,9 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
 {
     public class FieldReversePrintZplCommandAnalyzer : ZplCommandAnalyzerBase
     {
-        public FieldReversePrintZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^FR", virtualPrinter)
-        { }
+        public FieldReversePrintZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^FR", virtualPrinter) { }
 
+        ///<inheritdoc/>
         public override ZplElementBase Analyze(string zplCommand)
         {
             this.VirtualPrinter.SetNextElementFieldReverse();

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/FieldSeparatorZplCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/FieldSeparatorZplCommandAnalyzer.cs
@@ -6,13 +6,13 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
     {
         private ZplCommandAnalyzerBase _fieldDataAnalyzer;
 
-        public FieldSeparatorZplCommandAnalyzer(
-            VirtualPrinter virtualPrinter, ZplCommandAnalyzerBase fieldDataAnalyzer)
+        public FieldSeparatorZplCommandAnalyzer(VirtualPrinter virtualPrinter, ZplCommandAnalyzerBase fieldDataAnalyzer)
             : base("^FS", virtualPrinter)
         {
             _fieldDataAnalyzer = fieldDataAnalyzer;
         }
 
+        ///<inheritdoc/>
         public override ZplElementBase Analyze(string zplCommand)
         {
             // If next field number has been set and was not consumed by a field data

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/FieldTypesetZplCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/FieldTypesetZplCommandAnalyzer.cs
@@ -4,25 +4,27 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
 {
     public class FieldTypesetZplCommandAnalyzer : ZplCommandAnalyzerBase
     {
-        public FieldTypesetZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^FT", virtualPrinter)
-        { }
+        public FieldTypesetZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^FT", virtualPrinter) { }
 
+        ///<inheritdoc/>
         public override ZplElementBase Analyze(string zplCommand)
         {
             var zplDataParts = this.SplitCommand(zplCommand);
 
-            var x = 0;
-            var y = 0;
-            var z = 0;
+            int tmpint;
+            int x = 0;
+            int y = 0;
+            // TODO: Field Justification
+            //int z = 0;
 
-            _ = int.TryParse(zplDataParts[0], out x);
-            if (zplDataParts.Length > 1)
+            if (zplDataParts.Length > 0 && int.TryParse(zplDataParts[0], out tmpint))
             {
-                _ = int.TryParse(zplDataParts[1], out y);
+                x = tmpint;
             }
-            if (zplDataParts.Length > 2)
+
+            if (zplDataParts.Length > 1 && int.TryParse(zplDataParts[1], out tmpint))
             {
-                _ = int.TryParse(zplDataParts[2], out z);
+                y = tmpint;
             }
 
             if (this.VirtualPrinter.LabelHomePosition != null)

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/GraphicBoxZplCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/GraphicBoxZplCommandAnalyzer.cs
@@ -5,14 +5,21 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
 {
     public class GraphicBoxZplCommandAnalyzer : ZplCommandAnalyzerBase
     {
-        public GraphicBoxZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^GB", virtualPrinter)
-        { }
+        public GraphicBoxZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^GB", virtualPrinter) { }
 
+        ///<inheritdoc/>
         public override ZplElementBase Analyze(string zplCommand)
         {
-            var x = 0;
-            var y = 0;
-            var bottomToTop = false;
+            int tmpint;
+            int width = 1;
+            int height = 1;
+            int borderThickness = 1;
+            var lineColor = LineColor.Black;
+            int cornerRounding = 0;
+
+            int x = 0;
+            int y = 0;
+            bool bottomToTop = false;
 
             if (this.VirtualPrinter.NextElementPosition != null)
             {
@@ -24,31 +31,33 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
 
             var zplDataParts = this.SplitCommand(zplCommand);
 
-            _ = int.TryParse(zplDataParts[0], out var widht);
-            _ = int.TryParse(zplDataParts[1], out var height);
-            _ = int.TryParse(zplDataParts[2], out var borderThickness);
-
-            if (borderThickness > 8)
-            {
-                //error message -> not possible
+            if (zplDataParts.Length > 0 && int.TryParse(zplDataParts[0], out tmpint)) {
+                width= tmpint;
             }
 
-            var lineColor = LineColor.Black;
+            if (zplDataParts.Length > 1 && int.TryParse(zplDataParts[1], out tmpint)) {
+                height = tmpint;
+            }
+
+            if (zplDataParts.Length > 2 && int.TryParse(zplDataParts[2], out tmpint))
+            {
+                borderThickness = tmpint;
+            }
+
             if (zplDataParts.Length > 3)
             {
-                var lineColorTemp = zplDataParts[3];
+                string lineColorTemp = zplDataParts[3];
                 lineColor = lineColorTemp == "W" ? LineColor.White : LineColor.Black;
             }
 
-            var cornerRounding = 0;
-            if (zplDataParts.Length > 4)
+            if (zplDataParts.Length > 4 && int.TryParse(zplDataParts[4], out tmpint))
             {
-                _ = int.TryParse(zplDataParts[4], out cornerRounding);
+                cornerRounding = tmpint;
             }
 
-            var reversePrint = this.VirtualPrinter.NextElementFieldReverse || this.VirtualPrinter.LabelReverse;
+            bool reversePrint = this.VirtualPrinter.NextElementFieldReverse || this.VirtualPrinter.LabelReverse;
 
-            return new ZplGraphicBox(x, y, widht, height, borderThickness, lineColor, cornerRounding, reversePrint, bottomToTop);
+            return new ZplGraphicBox(x, y, width, height, borderThickness, lineColor, cornerRounding, reversePrint, bottomToTop);
         }
     }
 }

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/GraphicCircleZplCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/GraphicCircleZplCommandAnalyzer.cs
@@ -5,14 +5,19 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
 {
     public class GraphicCircleZplCommandAnalyzer : ZplCommandAnalyzerBase
     {
-        public GraphicCircleZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^GC", virtualPrinter)
-        { }
+        public GraphicCircleZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^GC", virtualPrinter) { }
 
+        ///<inheritdoc/>
         public override ZplElementBase Analyze(string zplCommand)
         {
-            var x = 0;
-            var y = 0;
-            var bottomToTop = false;
+            int tmpint;
+            int circleDiameter = 3;
+            int borderThickness = 1;
+            var lineColor = LineColor.Black;
+
+            int x = 0;
+            int y = 0;
+            bool bottomToTop = false;
 
             if (this.VirtualPrinter.NextElementPosition != null)
             {
@@ -23,13 +28,19 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
 
             var zplDataParts = this.SplitCommand(zplCommand);
 
-            _ = int.TryParse(zplDataParts[0], out var circleDiameter);
-            _ = int.TryParse(zplDataParts[1], out var borderThickness);
+            if (zplDataParts.Length > 0 && int.TryParse(zplDataParts[0], out tmpint))
+            {
+                circleDiameter = tmpint;
+            }
 
-            var lineColor = LineColor.Black;
+            if (zplDataParts.Length > 1 && int.TryParse(zplDataParts[1], out tmpint))
+            {
+                borderThickness = tmpint;
+            }
+
             if (zplDataParts.Length > 2)
             {
-                var lineColorTemp = zplDataParts[2];
+                string lineColorTemp = zplDataParts[2];
                 lineColor = lineColorTemp == "W" ? LineColor.White : LineColor.Black;
             }
 

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/GraphicFieldZplCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/GraphicFieldZplCommandAnalyzer.cs
@@ -7,14 +7,19 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
 {
     public class GraphicFieldZplCommandAnalyzer : ZplCommandAnalyzerBase
     {
-        public GraphicFieldZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^GF", virtualPrinter)
-        { }
+        public GraphicFieldZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^GF", virtualPrinter) { }
 
+        ///<inheritdoc/>
         public override ZplElementBase Analyze(string zplCommand)
         {
-            var x = 0;
-            var y = 0;
-            var bottomToTop = false;
+            int tmpint;
+            int binaryByteCount = 0;
+            int graphicFieldCount = 0;
+            int bytesPerRow = 0;
+
+            int x = 0;
+            int y = 0;
+            bool bottomToTop = false;
 
             if (this.VirtualPrinter.NextElementPosition != null)
             {
@@ -26,27 +31,26 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
 
             var zplDataParts = this.SplitCommand(zplCommand);
 
-            var compressionType = zplDataParts[0][0];
-            var binaryByteCount = 0;
-            var graphicFieldCount = 0;
-            var bytesPerRow = 0;
+            char compressionType = zplDataParts[0][0];
 
-            if (zplDataParts.Length > 1)
+            if (zplDataParts.Length > 1 && int.TryParse(zplDataParts[1], out tmpint))
             {
-                _ = int.TryParse(zplDataParts[1], out binaryByteCount);
+                binaryByteCount = tmpint;
             }
-            if (zplDataParts.Length > 2)
+
+            if (zplDataParts.Length > 2 && int.TryParse(zplDataParts[2], out tmpint))
             {
-                _ = int.TryParse(zplDataParts[2], out graphicFieldCount);
+                graphicFieldCount = tmpint;
             }
-            if (zplDataParts.Length > 3)
+
+            if (zplDataParts.Length > 3 && int.TryParse(zplDataParts[3], out tmpint))
             {
-                _ = int.TryParse(zplDataParts[3], out bytesPerRow);
+                bytesPerRow = tmpint;
             }
 
             //fourth comma is the start of the image data
-            var indexOfFourthComma = this.IndexOfNthCharacter(zplCommand, 4, ',');
-            var dataHex = zplCommand.Substring(indexOfFourthComma + 1);
+            int indexOfFourthComma = this.IndexOfNthCharacter(zplCommand, 4, ',');
+            string dataHex = zplCommand.Substring(indexOfFourthComma + 1);
 
             byte[] grfImageData = ImageHelper.GetImageBytes(dataHex, bytesPerRow);
 

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/IZplCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/IZplCommandAnalyzer.cs
@@ -2,10 +2,23 @@
 
 namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
 {
+    /// <summary>
+    /// Public interface for command analyzers
+    /// </summary>
     public interface IZplCommandAnalyzer
     {
+        /// <summary>
+        /// Checks if the analyzer can analyze this command
+        /// </summary>
+        /// <param name="zplLine"></param>
+        /// <returns></returns>
         bool CanAnalyze(string zplLine);
 
+        /// <summary>
+        /// Analyzes the command a returns the corresponding ZPL Element.
+        /// </summary>
+        /// <param name="zplCommand">The command to analyze.</param>
+        /// <returns></returns>
         ZplElementBase Analyze(string zplCommand);
     }
 }

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/ImageMoveZplCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/ImageMoveZplCommandAnalyzer.cs
@@ -4,13 +4,13 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
 {
     public class ImageMoveZplCommandAnalyzer : ZplCommandAnalyzerBase
     {
-        public ImageMoveZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^IM", virtualPrinter)
-        { }
+        public ImageMoveZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^IM", virtualPrinter) { }
 
+        ///<inheritdoc/>
         public override ZplElementBase Analyze(string zplCommand)
         {
-            var x = 0;
-            var y = 0;
+            int x = 0;
+            int y = 0;
 
             if (this.VirtualPrinter.NextElementPosition != null)
             {
@@ -18,12 +18,12 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
                 y = this.VirtualPrinter.NextElementPosition.Y;
             }
 
-            var zplCommandData = zplCommand.Substring(this.PrinterCommandPrefix.Length);
+            string zplCommandData = zplCommand.Substring(this.PrinterCommandPrefix.Length);
 
             //Get StorageDevice
-            var storageDevice = zplCommandData[0];
+            char storageDevice = zplCommandData[0];
 
-            var objectName = zplCommandData.Substring(2);
+            string objectName = zplCommandData.Substring(2);
 
             return new ZplImageMove(x, y, storageDevice, objectName, string.Empty);
         }

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/Interleaved2of5BarcodeZplCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/Interleaved2of5BarcodeZplCommandAnalyzer.cs
@@ -5,34 +5,36 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
 {
     public class Interleaved2of5BarcodeZplCommandAnalyzer : ZplCommandAnalyzerBase
     {
-        public Interleaved2of5BarcodeZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^B2", virtualPrinter)
-        { }
+        public Interleaved2of5BarcodeZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^B2", virtualPrinter) { }
 
+        ///<inheritdoc/>
         public override ZplElementBase Analyze(string zplCommand)
         {
             var zplDataParts = this.SplitCommand(zplCommand);
 
             var fieldOrientation = this.ConvertFieldOrientation(zplDataParts[0]);
-            var height = this.VirtualPrinter.BarcodeInfo.Height;
-            var printInterpretationLine = true;
-            var printInterpretationLineAboveCode = false;
-            var calculateAndPrintMod10CheckDigit = false;
 
-            if (zplDataParts.Length > 1)
+            int tmpint;
+            int height = this.VirtualPrinter.BarcodeInfo.Height;
+            bool printInterpretationLine = true;
+            bool printInterpretationLineAboveCode = false;
+            bool calculateAndPrintMod10CheckDigit = false;
+
+            if (zplDataParts.Length > 1 && int.TryParse(zplDataParts[1], out tmpint))
             {
-                if (!string.IsNullOrEmpty(zplDataParts[1]))
-                {
-                    _ = int.TryParse(zplDataParts[1], out height);
-                }
+                height = tmpint;
             }
+
             if (zplDataParts.Length > 2)
             {
                 printInterpretationLine = this.ConvertBoolean(zplDataParts[2], "Y");
             }
+
             if (zplDataParts.Length > 3)
             {
                 printInterpretationLineAboveCode = this.ConvertBoolean(zplDataParts[3]);
             }
+
             if (zplDataParts.Length > 4)
             {
                 calculateAndPrintMod10CheckDigit = this.ConvertBoolean(zplDataParts[4]);

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/LabelHomeZplCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/LabelHomeZplCommandAnalyzer.cs
@@ -4,15 +4,26 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
 {
     public class LabelHomeZplCommandAnalyzer : ZplCommandAnalyzerBase
     {
-        public LabelHomeZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^LH", virtualPrinter)
-        { }
+        public LabelHomeZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^LH", virtualPrinter) { }
 
+        ///<inheritdoc/>
         public override ZplElementBase Analyze(string zplCommand)
         {
             var zplDataParts = this.SplitCommand(zplCommand);
 
-            _ = int.TryParse(zplDataParts[0], out var x);
-            _ = int.TryParse(zplDataParts[1], out var y);
+            int tmpint;
+            int x = 0;
+            int y = 0;
+
+            if (zplDataParts.Length > 0 && int.TryParse(zplDataParts[0], out tmpint))
+            {
+                x = tmpint;
+            }
+
+            if (zplDataParts.Length > 1 && int.TryParse(zplDataParts[1], out tmpint))
+            {
+                y = tmpint;
+            }
 
             this.VirtualPrinter.SetLabelHome(x, y);
 

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/LabelReversePrintZplCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/LabelReversePrintZplCommandAnalyzer.cs
@@ -4,16 +4,21 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
 {
     public class LabelReversePrintZplCommandAnalyzer : ZplCommandAnalyzerBase
     {
-        public LabelReversePrintZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^LR", virtualPrinter)
-        { }
+        public LabelReversePrintZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^LR", virtualPrinter) { }
 
+        ///<inheritdoc/>
         public override ZplElementBase Analyze(string zplCommand)
         {
-            if (zplCommand.Length > 3)
+            var zplDataParts = this.SplitCommand(zplCommand);
+
+            bool reverse = false;
+
+            if (zplDataParts.Length > 0)
             {
-                var reverse = char.ToUpperInvariant(zplCommand[3]) == 'Y';
-                this.VirtualPrinter.SetLabelReverse(reverse);
+                reverse = this.ConvertBoolean(zplDataParts[0]);
             }
+
+            this.VirtualPrinter.SetLabelReverse(reverse);
             return null;
         }
     }

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/QrCodeBarcodeZplCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/QrCodeBarcodeZplCommandAnalyzer.cs
@@ -6,26 +6,29 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
 {
     public class QrCodeBarcodeZplCommandAnalyzer : ZplCommandAnalyzerBase
     {
-        public QrCodeBarcodeZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^BQ", virtualPrinter)
-        { }
+        public QrCodeBarcodeZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^BQ", virtualPrinter) { }
 
+        ///<inheritdoc/>
         public override ZplElementBase Analyze(string zplCommand)
         {
             var zplDataParts = this.SplitCommand(zplCommand);
 
             var fieldOrientation = this.ConvertFieldOrientation(zplDataParts[0]);
-            var model = 2;
-            var magnificationFactor = 3;
-            var errorCorrection = ErrorCorrectionLevel.HighReliability;
-            var maskValue = 7;
 
-            if (zplDataParts.Length > 1)
+            int tmpint;
+            int model = 2;
+            int magnificationFactor = 3;
+            var errorCorrection = ErrorCorrectionLevel.HighReliability;
+            int maskValue = 7;
+
+            if (zplDataParts.Length > 1 && int.TryParse(zplDataParts[1], out tmpint))
             {
-                _ = int.TryParse(zplDataParts[1], out model);
+                model = tmpint;
             }
-            if (zplDataParts.Length > 2)
+
+            if (zplDataParts.Length > 2 && int.TryParse(zplDataParts[2], out tmpint))
             {
-                _ = int.TryParse(zplDataParts[2], out magnificationFactor);
+                magnificationFactor = tmpint;
 
                 if (magnificationFactor > 10)
                 {
@@ -33,13 +36,15 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
                     magnificationFactor = 10;
                 }
             }
+
             if (zplDataParts.Length > 3)
             {
                 errorCorrection = this.ConvertErrorCorrectionLevel(zplDataParts[3]);
             }
-            if (zplDataParts.Length > 4)
+
+            if (zplDataParts.Length > 4 && int.TryParse(zplDataParts[4], out tmpint))
             {
-                _ = int.TryParse(zplDataParts[4], out maskValue);
+                maskValue = tmpint;
             }
 
             this.VirtualPrinter.SetNextElementFieldData(new QrCodeBarcodeFieldData

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/RecallFormatCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/RecallFormatCommandAnalyzer.cs
@@ -4,12 +4,13 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
 {
     public class RecallFormatCommandAnalyzer : ZplCommandAnalyzerBase
     {
-        public RecallFormatCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^XF", virtualPrinter)
-        { }
+        public RecallFormatCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^XF", virtualPrinter) { }
 
+        ///<inheritdoc/>
         public override ZplElementBase Analyze(string zplCommand)
         {
-            var formatName = zplCommand.Substring(this.PrinterCommandPrefix.Length);
+            string formatName = zplCommand.Substring(this.PrinterCommandPrefix.Length);
+
             return new ZplRecallFormat(formatName);
         }
     }

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/RecallGraphicZplCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/RecallGraphicZplCommandAnalyzer.cs
@@ -7,14 +7,14 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
     {
         private static readonly Regex commandRegex = new Regex(@"^\^XG(\w:)?(.*?\..+?)(?:,(\d*))?(?:,(\d*))?$", RegexOptions.Compiled);
 
-        public RecallGraphicZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^XG", virtualPrinter)
-        { }
+        public RecallGraphicZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^XG", virtualPrinter) { }
 
+        ///<inheritdoc/>
         public override ZplElementBase Analyze(string zplCommand)
         {
-            var x = 0;
-            var y = 0;
-            var bottomToTop = false;
+            int x = 0;
+            int y = 0;
+            bool bottomToTop = false;
 
             if (this.VirtualPrinter.NextElementPosition != null)
             {
@@ -27,10 +27,10 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
 
             if (commandMatch.Success)
             {
-                var storageDevice = commandMatch.Groups[1].Success ? commandMatch.Groups[1].Value[0] : 'R';
-                var imageName = commandMatch.Groups[2].Value;
-                var magnificationFactorX = commandMatch.Groups[3].Success ? int.Parse(commandMatch.Groups[3].Value) : 1;
-                var magnificationFactorY = commandMatch.Groups[4].Success ? int.Parse(commandMatch.Groups[4].Value) : 1;
+                char storageDevice = commandMatch.Groups[1].Success ? commandMatch.Groups[1].Value[0] : 'R';
+                string imageName = commandMatch.Groups[2].Value;
+                int magnificationFactorX = commandMatch.Groups[3].Success ? int.Parse(commandMatch.Groups[3].Value) : 1;
+                int magnificationFactorY = commandMatch.Groups[4].Success ? int.Parse(commandMatch.Groups[4].Value) : 1;
 
                 return new ZplRecallGraphic(x, y, storageDevice, imageName, magnificationFactorX, magnificationFactorY, bottomToTop);
             }

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/ScalableBitmappedFontZplCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/ScalableBitmappedFontZplCommandAnalyzer.cs
@@ -4,25 +4,29 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
 {
     public class ScalableBitmappedFontZplCommandAnalyzer : ZplCommandAnalyzerBase
     {
-        public ScalableBitmappedFontZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^A", virtualPrinter)
-        { }
+        public ScalableBitmappedFontZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^A", virtualPrinter) { }
 
+        ///<inheritdoc/>
         public override ZplElementBase Analyze(string zplCommand)
         {
-            var fontName = zplCommand[this.PrinterCommandPrefix.Length].ToString();
+            string fontName = zplCommand[this.PrinterCommandPrefix.Length].ToString();
 
             var zplDataParts = this.SplitCommand(zplCommand, 1);
 
             var fieldOrientation = this.ConvertFieldOrientation(zplDataParts[0]);
-            var fontHeight = this.VirtualPrinter.FontHeight;
-            var fontWidth = this.VirtualPrinter.FontWidth;
-            if (zplDataParts.Length > 1)
+
+            int tmpint;
+            int fontHeight = this.VirtualPrinter.FontHeight;
+            int fontWidth = this.VirtualPrinter.FontWidth;
+
+            if (zplDataParts.Length > 1 && int.TryParse(zplDataParts[1], out tmpint))
             {
-                _ = int.TryParse(zplDataParts[1], out fontHeight);
+                fontHeight = tmpint;
             }
-            if (zplDataParts.Length > 2)
+
+            if (zplDataParts.Length > 2 && int.TryParse(zplDataParts[2], out tmpint))
             {
-                _ = int.TryParse(zplDataParts[2], out fontWidth);
+                fontWidth = tmpint;
             }
 
             this.VirtualPrinter.SetNextFont(fontName, fieldOrientation, fontWidth, fontHeight);

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/ZplCommandAnalyzerBase.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/ZplCommandAnalyzerBase.cs
@@ -14,16 +14,18 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
             this.VirtualPrinter = virtualPrinter;
         }
 
+        ///<inheritdoc/>
         public bool CanAnalyze(string zplLine)
         {
             return zplLine.StartsWith(this.PrinterCommandPrefix);
         }
 
+        ///<inheritdoc/>
         public abstract ZplElementBase Analyze(string zplCommand);
 
         protected string[] SplitCommand(string zplCommand, int dataStartIndex = 0)
         {
-            var zplCommandData = zplCommand.Substring(this.PrinterCommandPrefix.Length + dataStartIndex);
+            string zplCommandData = zplCommand.Substring(this.PrinterCommandPrefix.Length + dataStartIndex);
             return zplCommandData.TrimStart().Split(',');
         }
 
@@ -58,8 +60,8 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
 
         protected int IndexOfNthCharacter(string input, int occurranceToFind, char charToFind)
         {
-            var index = -1;
-            for (var i = 0; i < occurranceToFind; i++)
+            int index = -1;
+            for (int i = 0; i < occurranceToFind; i++)
             {
                 index = input.IndexOf(charToFind, index + 1);
 


### PR DESCRIPTION
Fixes #173 

- Do not clobber default numeric values when parsing empty values
- Prefer explicit type for primitives
- Add missing doc strings