### PR TITLE
Fixed RenderModuleWidth() function to include WideBarToNarrowBarWidth…

### DIFF
--- a/src/BinaryKits.Zpl.Label.UnitTest/BarcodeTest.cs
+++ b/src/BinaryKits.Zpl.Label.UnitTest/BarcodeTest.cs
@@ -21,7 +21,7 @@ namespace BinaryKits.Zpl.Label.UnitTest
 
             Debug.WriteLine(output);
             Assert.IsNotNull(output);
-            Assert.AreEqual("^XA\n^LH0,0\n^CI28\n\n^FO100,100\n^BY2\n^B3N,N,100,Y,N\n^FD123ABC^FS\n^XZ", output);
+            Assert.AreEqual("^XA\n^LH0,0\n^CI28\n\n^FO100,100\n^BY2, 3\n^B3N,N,100,Y,N\n^FD123ABC^FS\n^XZ", output);
         }
 
         [TestMethod]
@@ -37,7 +37,7 @@ namespace BinaryKits.Zpl.Label.UnitTest
 
             Debug.WriteLine(output);
             Assert.IsNotNull(output);
-            Assert.AreEqual("^XA\n^LH0,0\n^CI28\n\n^FO100,300\n^BY2\n^BCN,100,Y,N\n^FD123ABC^FS\n^XZ", output);
+            Assert.AreEqual("^XA\n^LH0,0\n^CI28\n\n^FO100,300\n^BY2, 3\n^BCN,100,Y,N\n^FD123ABC^FS\n^XZ", output);
         }
 
         [TestMethod]
@@ -53,7 +53,7 @@ namespace BinaryKits.Zpl.Label.UnitTest
 
             Debug.WriteLine(output);
             Assert.IsNotNull(output);
-            Assert.AreEqual("^XA\n^LH0,0\n^CI28\n\n^FO100,300\n^BY2\n^BEN,100,Y,N\n^FD123456^FS\n^XZ", output);
+            Assert.AreEqual("^XA\n^LH0,0\n^CI28\n\n^FO100,300\n^BY2, 3\n^BEN,100,Y,N\n^FD123456^FS\n^XZ", output);
         }
     }
 }

--- a/src/BinaryKits.Zpl.Label.UnitTest/BarcodeTest.cs
+++ b/src/BinaryKits.Zpl.Label.UnitTest/BarcodeTest.cs
@@ -21,7 +21,7 @@ namespace BinaryKits.Zpl.Label.UnitTest
 
             Debug.WriteLine(output);
             Assert.IsNotNull(output);
-            Assert.AreEqual("^XA\n^LH0,0\n^CI28\n\n^FO100,100\n^BY2, 3\n^B3N,N,100,Y,N\n^FD123ABC^FS\n^XZ", output);
+            Assert.AreEqual("^XA\n^LH0,0\n^CI28\n\n^FO100,100\n^BY2,3\n^B3N,N,100,Y,N\n^FD123ABC^FS\n^XZ", output);
         }
 
         [TestMethod]
@@ -37,7 +37,7 @@ namespace BinaryKits.Zpl.Label.UnitTest
 
             Debug.WriteLine(output);
             Assert.IsNotNull(output);
-            Assert.AreEqual("^XA\n^LH0,0\n^CI28\n\n^FO100,300\n^BY2, 3\n^BCN,100,Y,N\n^FD123ABC^FS\n^XZ", output);
+            Assert.AreEqual("^XA\n^LH0,0\n^CI28\n\n^FO100,300\n^BY2,3\n^BCN,100,Y,N\n^FD123ABC^FS\n^XZ", output);
         }
 
         [TestMethod]
@@ -53,7 +53,7 @@ namespace BinaryKits.Zpl.Label.UnitTest
 
             Debug.WriteLine(output);
             Assert.IsNotNull(output);
-            Assert.AreEqual("^XA\n^LH0,0\n^CI28\n\n^FO100,300\n^BY2, 3\n^BEN,100,Y,N\n^FD123456^FS\n^XZ", output);
+            Assert.AreEqual("^XA\n^LH0,0\n^CI28\n\n^FO100,300\n^BY2,3\n^BEN,100,Y,N\n^FD123456^FS\n^XZ", output);
         }
     }
 }

--- a/src/BinaryKits.Zpl.Label/Elements/ZplBarcode.cs
+++ b/src/BinaryKits.Zpl.Label/Elements/ZplBarcode.cs
@@ -55,7 +55,7 @@
 
         protected string RenderModuleWidth()
         {
-            return $"^BY{ModuleWidth}";
+            return $"^BY{ModuleWidth}, {WideBarToNarrowBarWidthRatio}";
         }
 
         protected bool IsDigitsOnly(string text)

--- a/src/BinaryKits.Zpl.Label/Elements/ZplBarcode.cs
+++ b/src/BinaryKits.Zpl.Label/Elements/ZplBarcode.cs
@@ -55,7 +55,7 @@
 
         protected string RenderModuleWidth()
         {
-            return $"^BY{ModuleWidth}, {WideBarToNarrowBarWidthRatio}";
+            return $"^BY{ModuleWidth},{WideBarToNarrowBarWidthRatio}";
         }
 
         protected bool IsDigitsOnly(string text)


### PR DESCRIPTION
…Ratio in return string.  The wide bar to narrow bar width ratio is not being added when the global bar code defaults are set in RenderModuleWidth() function.  This simply adds the value stored in the WideBarToNarrowBarWidthRatio property to the RenderModuleWidth() return string.