### PR TITLE
String parsing analyzer to replace regex split, enables ^CC and ^CT commands

### DIFF
--- a/src/BinaryKits.Zpl.Viewer/ZplAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/ZplAnalyzer.cs
@@ -166,8 +166,8 @@ namespace BinaryKits.Zpl.Viewer
             }
             return results.ToArray();
         }
-        
-		private void patch_command(ref string command, ref char caret, ref char tilde) 
+
+        private void patch_command(ref string command, ref char caret, ref char tilde) 
         {
             if (caret != '^' && command[0] == caret)
             {


### PR DESCRIPTION
ZPL ^FD commands sometimes come with ^ and ~ characters in the data. This breaks the parser which sees unrecognized commands. The way these are stored is by swapping out the caret(CC) or tilde(CT) characters with an unused one momentarily before reading the FD data, then swapping back the original symbol(s) after.

This still returns an array of strings like the old `SplitZplCommands` signature.

We patch back the commands with the default caret and tilde so that the command analyzers do not have to be modified.

The capacity sizes for the buffers are arbitrary, but what I'd consider a reasonable amount for shipping labels.

Ideally, there would be work to support the ^~~CS~~CD command as well, but because most command analyzers rely on splitting on commas, there are architectural discussions to be had prior.