### PR TITLE
Enable opaque backgrounds

### DIFF
--- a/src/BinaryKits.Zpl.Viewer/ElementDrawers/DrawerOptions.cs
+++ b/src/BinaryKits.Zpl.Viewer/ElementDrawers/DrawerOptions.cs
@@ -10,6 +10,11 @@ namespace BinaryKits.Zpl.Viewer.ElementDrawers
 
         public SKEncodedImageFormat RenderFormat { get; set; } = SKEncodedImageFormat.Png;
 
+        /// <summary>
+        /// Applies label over a white background after rendering all elements
+        /// </summary>
+        public bool OpaqueBackground { get; set; } = false;
+
         public int RenderQuality { get; set; } = 80;
 
         public bool ReplaceDashWithEnDash { get; set; } = true;

--- a/src/BinaryKits.Zpl.Viewer/ZplElementDrawer.cs
+++ b/src/BinaryKits.Zpl.Viewer/ZplElementDrawer.cs
@@ -100,7 +100,26 @@ namespace BinaryKits.Zpl.Viewer
                 }
             }
 
-            using var data = skBitmap.Encode(_drawerOptions.RenderFormat, _drawerOptions.RenderQuality);
+            SKBitmap finalBitmap;
+            if (this._drawerOptions.OpaqueBackground == true)
+            {
+                finalBitmap = new SKBitmap(labelImageWidth, labelImageHeight);
+                using (SKCanvas canvas = new SKCanvas(finalBitmap))
+                {
+                    SKPaint paint = new SKPaint
+                    {
+                        IsAntialias = true,
+                        FilterQuality = SKFilterQuality.High
+                    };
+                    canvas.Clear(SKColors.White);
+                    canvas.DrawBitmap(skBitmap, 0, 0, paint);
+                }
+            }
+            else {
+                finalBitmap = skBitmap;
+            }
+
+            using var data = finalBitmap.Encode(_drawerOptions.RenderFormat, _drawerOptions.RenderQuality);
             return data.ToArray();
         }
 


### PR DESCRIPTION
Transparent pngs do not work well with image viewers that have a dark background.

Due to the `InvertDraw` code, we cannot enable it at the original canvas creation time.

Perhaps should there be an option to set the background color as well?