### PR TITLE
Added: Font fallback structure for the default fonts.

### DIFF
--- a/src/BinaryKits.Zpl.Viewer/ElementDrawers/DrawerOptions.cs
+++ b/src/BinaryKits.Zpl.Viewer/ElementDrawers/DrawerOptions.cs
@@ -76,13 +76,11 @@ namespace BinaryKits.Zpl.Viewer.ElementDrawers
             }
             else
             {
-                //Note: It looks like Labelary doesn't allow a fontsize below 20 for mono space
-                if (fontFamilies.Contains("Courier"))
+                if (fontFamilies.Contains("DejaVu Sans Mono"))
                 {
-                    //typeface = SKTypeface.FromFile(@"swiss-721-black-bt.ttf");
                     typeface = SKTypeface.FromFamilyName(
-                        "Courier New",
-                        SKFontStyleWeight.Medium,
+                        "DejaVu Sans Mono",
+                        SKFontStyleWeight.Normal,
                         SKFontStyleWidth.Normal,
                         SKFontStyleSlant.Upright
                     );
@@ -91,6 +89,15 @@ namespace BinaryKits.Zpl.Viewer.ElementDrawers
                 {
                     typeface = SKTypeface.FromFamilyName(
                         "Courier New",
+                        SKFontStyleWeight.Medium,
+                        SKFontStyleWidth.Normal,
+                        SKFontStyleSlant.Upright
+                    );
+                }
+                else if (fontFamilies.Contains("Courier"))
+                {
+                    typeface = SKTypeface.FromFamilyName(
+                        "Courier",
                         SKFontStyleWeight.Medium,
                         SKFontStyleWidth.Normal,
                         SKFontStyleSlant.Upright

--- a/src/BinaryKits.Zpl.Viewer/ElementDrawers/DrawerOptions.cs
+++ b/src/BinaryKits.Zpl.Viewer/ElementDrawers/DrawerOptions.cs
@@ -1,6 +1,7 @@
 using SkiaSharp;
 using System;
 using System.Diagnostics;
+using System.Linq;
 
 namespace BinaryKits.Zpl.Viewer.ElementDrawers
 {
@@ -21,14 +22,90 @@ namespace BinaryKits.Zpl.Viewer.ElementDrawers
 
         public static Func<string, SKTypeface> DefaultFontLoader = fontName => {
             var typeface = SKTypeface.Default;
+            var skFontManager = SKFontManager.Default;
+            var fontFamilies = skFontManager.FontFamilies;
+            
             if (fontName == "0")
             {
-                //typeface = SKTypeface.FromFile(@"swiss-721-black-bt.ttf");
-                typeface = SKTypeface.FromFamilyName("Helvetica", SKFontStyleWeight.Bold, SKFontStyleWidth.SemiCondensed, SKFontStyleSlant.Upright);
+                if (fontFamilies.Contains("Helvetica"))
+                {
+                    typeface = SKTypeface.FromFamilyName(
+                        "Helvetica",
+                        SKFontStyleWeight.Bold,
+                        SKFontStyleWidth.SemiCondensed,
+                        SKFontStyleSlant.Upright
+                    );
+                }
+                else if (fontFamilies.Contains("Roboto Condensed"))
+                {
+                    typeface = SKTypeface.FromFamilyName(
+                        "Roboto Condensed",
+                        SKFontStyleWeight.Bold,
+                        SKFontStyleWidth.Normal,
+                        SKFontStyleSlant.Upright
+                    );
+                }
+                else if (fontFamilies.Contains("Swis721 BT"))
+                {
+                    //Note: Zebra Swis721 BT (tt0003m_.ttf) is not as bold and condensed as Labelary
+                    //Note: swiss-721-bt-bold.ttf is not as condensed as Labelary
+                    //typeface = SKTypeface.FromFile(@"swiss-721-black-bt.ttf");
+                    typeface = SKTypeface.FromFamilyName(
+                        "Swis721 BT"
+                    );
+                }
+                else if (fontFamilies.Contains("Arial"))
+                {
+                    typeface = SKTypeface.FromFamilyName(
+                        "Arial",
+                        SKFontStyleWeight.Bold,
+                        SKFontStyleWidth.Condensed,
+                        SKFontStyleSlant.Upright
+                    );
+                }
+                else
+                {
+                    //let the system provide a fallback for Helvetica
+                    typeface = SKTypeface.FromFamilyName(
+                        "Helvetica",
+                        SKFontStyleWeight.Bold,
+                        SKFontStyleWidth.SemiCondensed,
+                        SKFontStyleSlant.Upright
+                    );
+                }
             }
             else
             {
-                typeface = SKTypeface.FromFamilyName("DejaVu Sans Mono", SKFontStyleWeight.Normal, SKFontStyleWidth.Normal, SKFontStyleSlant.Upright);
+                //Note: It looks like Labelary doesn't allow a fontsize below 20 for mono space
+                if (fontFamilies.Contains("Courier"))
+                {
+                    //typeface = SKTypeface.FromFile(@"swiss-721-black-bt.ttf");
+                    typeface = SKTypeface.FromFamilyName(
+                        "Courier New",
+                        SKFontStyleWeight.Medium,
+                        SKFontStyleWidth.Normal,
+                        SKFontStyleSlant.Upright
+                    );
+                }
+                else if (fontFamilies.Contains("Courier New"))
+                {
+                    typeface = SKTypeface.FromFamilyName(
+                        "Courier New",
+                        SKFontStyleWeight.Medium,
+                        SKFontStyleWidth.Normal,
+                        SKFontStyleSlant.Upright
+                    );
+                }
+                else
+                {
+                    //let the system provide a fallback for DejaVu
+                    typeface = SKTypeface.FromFamilyName(
+                        "DejaVu Sans Mono",
+                        SKFontStyleWeight.Normal,
+                        SKFontStyleWidth.Normal,
+                        SKFontStyleSlant.Upright
+                    );
+                }
             }
 
             return typeface;

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update \
     libc6-dev \
     libgdiplus \
     libx11-dev \
+    fonts-roboto \
  && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app


### PR DESCRIPTION
I ran into the same issue as #204; the dockerized environment is missing the required fonts, and getting those there is a pain.

So I made a fallback structure that looks for available fonts in the following order:
- Helvetica
- Roboto Condensed
- Swis721 BT
- Arial (Narrow)
- System fallback for Helvetica

For the monospace fonttype it is:
- Courier
- Courier New
- System fallback for DejaVu Sans Mono

Now you get a close result on most environments. Especially the docker container can profit from this, with the command `apt install fonts-roboto` you can use Roboto Condensed and that should give this result:

<img width="410" alt="image" src="https://github.com/BinaryKits/BinaryKits.Zpl/assets/12891775/579b01df-53d9-4729-a02c-ac0829363373">

