### PR TITLE
Improved: Enabled antialiased text

### DIFF
--- a/src/BinaryKits.Zpl.Viewer/ElementDrawers/FieldBlockElementDrawer.cs
+++ b/src/BinaryKits.Zpl.Viewer/ElementDrawers/FieldBlockElementDrawer.cs
@@ -61,7 +61,7 @@ namespace BinaryKits.Zpl.Viewer.ElementDrawers
                 }
 
                 var skFont = new SKFont(typeface, fontSize, scaleX);
-                using var skPaint = new SKPaint(skFont);
+                using var skPaint = new SKPaint(skFont) { IsAntialias = true, };
                 var textBoundBaseline = new SKRect();
                 skPaint.MeasureText("X", ref textBoundBaseline);
 

--- a/src/BinaryKits.Zpl.Viewer/ElementDrawers/TextFieldElementDrawer.cs
+++ b/src/BinaryKits.Zpl.Viewer/ElementDrawers/TextFieldElementDrawer.cs
@@ -50,7 +50,7 @@ namespace BinaryKits.Zpl.Viewer.ElementDrawers
                 var typeface = options.FontLoader(font.FontName);
 
                 var skFont = new SKFont(typeface, fontSize, scaleX);
-                using var skPaint = new SKPaint(skFont);
+                using var skPaint = new SKPaint(skFont) { IsAntialias = true, };
 
                 string displayText = textField.Text;
                 if (textField.UseHexadecimalIndicator)


### PR DESCRIPTION
Enabling antialiasing on fonts gives a much nicer and more readable text.

![font-antialiasing-enabled](https://github.com/BinaryKits/BinaryKits.Zpl/assets/12891775/177d7f98-f9f4-4eb8-95fb-e1711e345e1b)
(Top: enabled vs bottom: current)

You can preview it here: https://binarykits.dvdg.nu/