### PR TITLE
Rework font stack

### DIFF
--- a/src/BinaryKits.Zpl.Viewer/ElementDrawers/DrawerOptions.cs
+++ b/src/BinaryKits.Zpl.Viewer/ElementDrawers/DrawerOptions.cs
@@ -1,6 +1,5 @@
 using SkiaSharp;
 using System;
-using System.Diagnostics;
 using System.Linq;
 
 namespace BinaryKits.Zpl.Viewer.ElementDrawers
@@ -17,7 +16,7 @@ namespace BinaryKits.Zpl.Viewer.ElementDrawers
         /// Applies label over a white background after rendering all elements
         /// </summary>
         public bool OpaqueBackground { get; set; } = false;
-        
+
         /// <summary>
         /// Renders the label as pdf
         /// </summary>
@@ -27,102 +26,69 @@ namespace BinaryKits.Zpl.Viewer.ElementDrawers
 
         public bool Antialias { get; set; } = true;
 
-        public static Func<string, SKTypeface> DefaultFontLoader = fontName => {
-            var typeface = SKTypeface.Default;
+        private static readonly string[] fontStack0 = new string[] {
+            "Swis721 Cn BT",
+            "Nimbus Sans",
+            "Arial",
+            "Helvetica Neue",
+            "Roboto Condensed"
+        };
+
+        private static readonly string[] fontStackA = new string[] {
+            "DejaVu Sans Mono",
+            "Cascadia Code",
+            "Consolas",
+            "SF Mono",
+            "Droid Sans Mono"
+        };
+
+        private static readonly SKTypeface typeface0;
+        private static readonly SKTypeface typefaceA;
+
+        static DrawerOptions()
+        {
             var skFontManager = SKFontManager.Default;
             var fontFamilies = skFontManager.FontFamilies;
-            
-            if (fontName == "0")
+
+            typeface0 = SKTypeface.Default;
+            typefaceA = SKTypeface.Default;
+
+            foreach (var familyName in fontStack0)
             {
-                if (fontFamilies.Contains("Helvetica"))
+                if (fontFamilies.Contains(familyName))
                 {
-                    typeface = SKTypeface.FromFamilyName(
-                        "Helvetica",
+                    typeface0 = SKTypeface.FromFamilyName(
+                        familyName,
                         SKFontStyleWeight.Bold,
                         SKFontStyleWidth.SemiCondensed,
                         SKFontStyleSlant.Upright
                     );
-                }
-                else if (fontFamilies.Contains("Roboto Condensed"))
-                {
-                    typeface = SKTypeface.FromFamilyName(
-                        "Roboto Condensed",
-                        SKFontStyleWeight.Bold,
-                        SKFontStyleWidth.Normal,
-                        SKFontStyleSlant.Upright
-                    );
-                }
-                else if (fontFamilies.Contains("Swis721 BT"))
-                {
-                    //Note: Zebra Swis721 BT (tt0003m_.ttf) is not as bold and condensed as Labelary
-                    //Note: swiss-721-bt-bold.ttf is not as condensed as Labelary
-                    //typeface = SKTypeface.FromFile(@"swiss-721-black-bt.ttf");
-                    typeface = SKTypeface.FromFamilyName(
-                        "Swis721 BT"
-                    );
-                }
-                else if (fontFamilies.Contains("Arial"))
-                {
-                    typeface = SKTypeface.FromFamilyName(
-                        "Arial",
-                        SKFontStyleWeight.Bold,
-                        SKFontStyleWidth.Condensed,
-                        SKFontStyleSlant.Upright
-                    );
-                }
-                else
-                {
-                    //let the system provide a fallback for Helvetica
-                    typeface = SKTypeface.FromFamilyName(
-                        "Helvetica",
-                        SKFontStyleWeight.Bold,
-                        SKFontStyleWidth.SemiCondensed,
-                        SKFontStyleSlant.Upright
-                    );
-                }
-            }
-            else
-            {
-                if (fontFamilies.Contains("DejaVu Sans Mono"))
-                {
-                    typeface = SKTypeface.FromFamilyName(
-                        "DejaVu Sans Mono",
-                        SKFontStyleWeight.Normal,
-                        SKFontStyleWidth.Normal,
-                        SKFontStyleSlant.Upright
-                    );
-                }
-                else if (fontFamilies.Contains("Courier New"))
-                {
-                    typeface = SKTypeface.FromFamilyName(
-                        "Courier New",
-                        SKFontStyleWeight.Medium,
-                        SKFontStyleWidth.Normal,
-                        SKFontStyleSlant.Upright
-                    );
-                }
-                else if (fontFamilies.Contains("Courier"))
-                {
-                    typeface = SKTypeface.FromFamilyName(
-                        "Courier",
-                        SKFontStyleWeight.Medium,
-                        SKFontStyleWidth.Normal,
-                        SKFontStyleSlant.Upright
-                    );
-                }
-                else
-                {
-                    //let the system provide a fallback for DejaVu
-                    typeface = SKTypeface.FromFamilyName(
-                        "DejaVu Sans Mono",
-                        SKFontStyleWeight.Normal,
-                        SKFontStyleWidth.Normal,
-                        SKFontStyleSlant.Upright
-                    );
+                    break;
                 }
             }
 
-            return typeface;
+            foreach (var familyName in fontStackA)
+            {
+                if (fontFamilies.Contains(familyName))
+                {
+                    typefaceA = SKTypeface.FromFamilyName(
+                        familyName,
+                        SKFontStyleWeight.Normal,
+                        SKFontStyleWidth.Normal,
+                        SKFontStyleSlant.Upright
+                    );
+                    break;
+                }
+            }
+        }
+
+        private static Func<string, SKTypeface> DefaultFontLoader = fontName => {
+            if (fontName == "0")
+            {
+                return typeface0;
+            }
+
+            return typefaceA;
         };
     }
 }


### PR DESCRIPTION
Only load default fonts once, rather than each time they are used.
Reorder font preference in the order (Zebra), Linux, Windows, MacOS, Android.