### PR TITLE
Fixed parsing of CT and CC commands.

### DIFF
--- a/src/BinaryKits.Zpl.Viewer/ZplAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/ZplAnalyzer.cs
@@ -162,11 +162,13 @@ namespace BinaryKits.Zpl.Viewer
 
                         if (commandLetters == "CT")
                         {
-                            tilde = command[3];
+                            tilde = c;
+                            continue;
                         }
                         else if (commandLetters == "CC")
                         {
-                            caret = command[3];
+                            caret = c;
+                            continue;
                         }
                         else if (!ignoredCommandsHS.Contains(commandLetters))
                         {


### PR DESCRIPTION
Fix of issue #266 
Error occurs while parsing CT and CC commands, when default char is set (~CT~ and ~CC^).
Because of tilde and caret chars are defined as begin of a new command, when these chars are found, parser stop previous command and add these chars to the next one, resulting in command being "~CC" (or ~CT) without the last char.

Fixed issue by replacing caret and tilde chars from being the last char of the command to being the current char in buffer, since these commands always expect to have replacing char specified.