### PR TITLE
Fix missing data matrix quality parameter

### DIFF
--- a/src/BinaryKits.Zpl.Label/Elements/ZplDataMatrix.cs
+++ b/src/BinaryKits.Zpl.Label/Elements/ZplDataMatrix.cs
@@ -50,7 +50,7 @@ namespace BinaryKits.Zpl.Label.Elements
             //^FDZEBRA TECHNOLOGIES CORPORATION ^ FS
             var result = new List<string>();
             result.AddRange(RenderPosition(context));
-            result.Add($"^BX{RenderFieldOrientation()},{context.Scale(Height)}");
+            result.Add($"^BX{RenderFieldOrientation()},{context.Scale(Height)},200");
             result.Add($"^FD{Content}^FS");
 
             return result;


### PR DESCRIPTION
The quality parameter of the data matrix command was missing. This commit fix the issue.

As you can see in the code comment above, there is the mandatory `quality` parameter set to 200, which is the only valid value now.

Labelary documentation of the quality parameter:

> **quality**: The level of error correction to apply. Valid values are 0 (ECC 0), 50 (ECC 50), 80 (ECC 80), 100 (ECC 100), 140 (ECC 140) and 200 (ECC 200). The default value is 0 (scan errors are detected but not corrected). Always use quality level 200 (ECC 200).