### PR TITLE
issue 276 allow non-integer inputs to FO analyzer

### DIFF
--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/FieldOriginZplCommandAnalzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/FieldOriginZplCommandAnalzer.cs
@@ -1,4 +1,5 @@
-﻿using BinaryKits.Zpl.Label.Elements;
+﻿using System;
+using BinaryKits.Zpl.Label.Elements;
 
 namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
 {
@@ -11,20 +12,29 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
         {
             var zplDataParts = this.SplitCommand(zplCommand);
 
-            int tmpint;
             int x = 0;
             int y = 0;
+            decimal tempdec;
             // TODO: Field Justification
             //int z = 0;
 
-            if (zplDataParts.Length > 0 && int.TryParse(zplDataParts[0], out tmpint))
-            {
-                x = tmpint;
-            }
+            if (zplDataParts.Length > 0 && 
+                decimal.TryParse(zplDataParts[0], out tempdec) && 
+                int.MinValue <= tempdec && 
+                tempdec <= int.MaxValue
+                )
+              {
+                x = Decimal.ToInt32(tempdec);
+              }
+            
 
-            if (zplDataParts.Length > 1 && int.TryParse(zplDataParts[1], out tmpint))
+            if (zplDataParts.Length > 1 && 
+                decimal.TryParse(zplDataParts[1], out tempdec) &&
+                int.MinValue <= tempdec && 
+                tempdec <= int.MaxValue
+               )
             {
-                y = tmpint;
+                y = Decimal.ToInt32(tempdec);
             }
 
             if (zplDataParts.Length > 2)


### PR DESCRIPTION
This PR is for [issue 276](https://github.com/BinaryKits/BinaryKits.Zpl/issues/276) which loosens the field origin analyzer to accept non-integer values and truncates to decimal, provided they are in range for an int, versus the current behavior to ignore and default to a zero value.  Per the issue, I believe this has no compatibility issues with the library as is and puts this closer to parity with labelary's behavior.